### PR TITLE
Organize perturbation schemes

### DIFF
--- a/python_tsp/heuristics/local_search.py
+++ b/python_tsp/heuristics/local_search.py
@@ -1,10 +1,11 @@
-"""Module with a 2-opt local search solver"""
-from typing import Callable, Dict, Generator, List, Optional, Tuple
+"""Simple local search solver"""
+from typing import List, Optional, Tuple
 import random
 
 import numpy as np
 
 from python_tsp.utils import compute_permutation_distance
+from python_tsp.heuristics.perturbation_schemes import neighborhood_gen
 
 
 def solve_tsp_local_search(
@@ -52,13 +53,7 @@ def solve_tsp_local_search(
     International Journal of Electrical Power & Energy Systems 101 (2018):
     339-355.
     """
-    neighborhood_gen: Dict[
-        str, Callable[[List[int]], Generator[List[int], List[int], None]]
-    ] = {
-        "ps1": ps1_gen, "ps2": ps2_gen, "ps3": ps3_gen,
-    }
-
-    x, fx = _setup(distance_matrix, x0)
+    x, fx = setup(distance_matrix, x0)
 
     improvement = True
     while improvement:
@@ -73,7 +68,7 @@ def solve_tsp_local_search(
     return x, fx
 
 
-def _setup(
+def setup(
     distance_matrix: np.ndarray, x0: Optional[List] = None
 ) -> Tuple[List[int], float]:
     """Return initial solution and its objective value
@@ -104,47 +99,3 @@ def _setup(
 
     fx0 = compute_permutation_distance(distance_matrix, x0)
     return x0, fx0
-
-
-def ps1_gen(x: List[int]) -> Generator[List[int], List[int], None]:
-    """PS1 perturbation scheme: Swap two adjacent terms
-    This scheme has at most n - 1 swaps.
-    """
-
-    n = len(x)
-    i_range = range(1, n - 1)
-    for i in random.sample(i_range, len(i_range)):
-        xn = x.copy()
-        xn[i], xn[i + 1] = x[i + 1], xn[i]
-        yield xn
-
-
-def ps2_gen(x: List[int]) -> Generator[List[int], List[int], None]:
-    """PS2 perturbation scheme: Swap any two elements
-    This scheme has n * (n - 1) / 2 swaps.
-    """
-
-    n = len(x)
-    i_range = range(1, n - 1)
-    for i in random.sample(i_range, len(i_range)):
-        j_range = range(i + 1, n)
-        for j in random.sample(j_range, len(j_range)):
-            xn = x.copy()
-            xn[i], xn[j] = xn[j], xn[i]
-            yield xn
-
-
-def ps3_gen(x: List[int]) -> Generator[List[int], List[int], None]:
-    """PS3 perturbation scheme: A single term is moved
-    This scheme has n * (n - 1) swaps.
-    """
-
-    n = len(x)
-    i_range = range(1, n)
-    for i in random.sample(i_range, len(i_range)):
-        j_range = [j for j in range(1, n) if j != i]
-        for j in random.sample(j_range, len(j_range)):
-            xn = x.copy()
-            node = xn.pop(i)
-            xn.insert(j, node)
-            yield xn

--- a/python_tsp/heuristics/perturbation_schemes.py
+++ b/python_tsp/heuristics/perturbation_schemes.py
@@ -1,0 +1,61 @@
+"""Perturbation schemes used in local search-based algorithms.
+The functions here should receive a permutation list with numbers from 0 to `n`
+and return a generator with all neighbors of this permutation.
+The neighbors should preferably be randomized to be used in Simulated
+Annealing, which samples a single neighbor at a time.
+"""
+from typing import Callable, Dict, Generator, List
+
+import random
+
+
+def ps1_gen(x: List[int]) -> Generator[List[int], List[int], None]:
+    """PS1 perturbation scheme: Swap two adjacent terms
+    This scheme has at most n - 1 swaps.
+    """
+
+    n = len(x)
+    i_range = range(1, n - 1)
+    for i in random.sample(i_range, len(i_range)):
+        xn = x.copy()
+        xn[i], xn[i + 1] = x[i + 1], xn[i]
+        yield xn
+
+
+def ps2_gen(x: List[int]) -> Generator[List[int], List[int], None]:
+    """PS2 perturbation scheme: Swap any two elements
+    This scheme has n * (n - 1) / 2 swaps.
+    """
+
+    n = len(x)
+    i_range = range(1, n - 1)
+    for i in random.sample(i_range, len(i_range)):
+        j_range = range(i + 1, n)
+        for j in random.sample(j_range, len(j_range)):
+            xn = x.copy()
+            xn[i], xn[j] = xn[j], xn[i]
+            yield xn
+
+
+def ps3_gen(x: List[int]) -> Generator[List[int], List[int], None]:
+    """PS3 perturbation scheme: A single term is moved
+    This scheme has n * (n - 1) swaps.
+    """
+
+    n = len(x)
+    i_range = range(1, n)
+    for i in random.sample(i_range, len(i_range)):
+        j_range = [j for j in range(1, n) if j != i]
+        for j in random.sample(j_range, len(j_range)):
+            xn = x.copy()
+            node = xn.pop(i)
+            xn.insert(j, node)
+            yield xn
+
+
+# Mapping with all possible neighborhood generators in this module
+neighborhood_gen: Dict[
+    str, Callable[[List[int]], Generator[List[int], List[int], None]]
+] = {
+    "ps1": ps1_gen, "ps2": ps2_gen, "ps3": ps3_gen,
+}

--- a/python_tsp/heuristics/simulated_annealing.py
+++ b/python_tsp/heuristics/simulated_annealing.py
@@ -1,8 +1,9 @@
-from typing import Callable, Dict, Generator, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 
-from python_tsp.heuristics import local_search
+from python_tsp.heuristics.perturbation_schemes import neighborhood_gen
+from python_tsp.heuristics.local_search import setup
 from python_tsp.utils import compute_permutation_distance
 
 
@@ -57,7 +58,7 @@ def solve_tsp_simulated_annealing(
     339-355.
     """
 
-    x, fx = local_search._setup(distance_matrix, x0)
+    x, fx = setup(distance_matrix, x0)
     temp = initial_temperature(distance_matrix, x, fx, perturbation_scheme)
 
     n = len(x)
@@ -140,14 +141,6 @@ def _perturbation(x: List[int], perturbation_scheme: str = "ps3"):
     module, and pick the first solution. Since the neighborhood is randomized,
     it is the same as creating a random perturbation.
     """
-    neighborhood_gen: Dict[
-        str, Callable[[List[int]], Generator[List[int], List[int], None]]
-    ] = {
-        "ps1": local_search.ps1_gen,
-        "ps2": local_search.ps2_gen,
-        "ps3": local_search.ps3_gen,
-    }
-
     return next(neighborhood_gen[perturbation_scheme](x))
 
 

--- a/python_tsp/heuristics/simulated_annealing.py
+++ b/python_tsp/heuristics/simulated_annealing.py
@@ -59,7 +59,7 @@ def solve_tsp_simulated_annealing(
     """
 
     x, fx = setup(distance_matrix, x0)
-    temp = initial_temperature(distance_matrix, x, fx, perturbation_scheme)
+    temp = _initial_temperature(distance_matrix, x, fx, perturbation_scheme)
 
     n = len(x)
     k_inner_min = 12 * n  # min inner iterations
@@ -72,7 +72,7 @@ def solve_tsp_simulated_annealing(
             xn = _perturbation(x, perturbation_scheme)
             fn = compute_permutation_distance(distance_matrix, xn)
 
-            if acceptance_rule(fx, fn, temp):
+            if _acceptance_rule(fx, fn, temp):
                 x, fx = xn, fn
                 k_accepted += 1
                 k_noimprovements = 0
@@ -96,7 +96,7 @@ def solve_tsp_simulated_annealing(
     return x, fx
 
 
-def initial_temperature(
+def _initial_temperature(
     distance_matrix: np.ndarray,
     x: List[int],
     fx: float,
@@ -144,7 +144,7 @@ def _perturbation(x: List[int], perturbation_scheme: str = "ps3"):
     return next(neighborhood_gen[perturbation_scheme](x))
 
 
-def acceptance_rule(fx: float, fn: float, temp: float) -> bool:
+def _acceptance_rule(fx: float, fn: float, temp: float) -> bool:
     """Metropolis acceptance rule"""
 
     dfx = fn - fx

--- a/tests/test_local_search.py
+++ b/tests/test_local_search.py
@@ -20,37 +20,6 @@ class TestImportModule:
         )
 
 
-class TestPerturbationSchemes:
-    x = [0, 1, 2, 3, 4]
-
-    def test_ps1_returns_correct_num_neighbors(self):
-        """PS1 has n - 1 swaps.
-        But since we fix the first element as origin, it leads to n - 2 = 3 in
-        this case.
-        """
-
-        all_neighbors = list(local_search.ps1_gen(self.x))
-        assert len(all_neighbors) == 3
-
-    def test_ps2_returns_correct_num_neighbors(self):
-        """PS2 has n * (n - 1) / 2 swaps.
-        But since we fix the first element as origin, it leads to
-        (n - 1) * (n - 2) / 2 = 6 in this case.
-        """
-
-        all_neighbors = list(local_search.ps2_gen(self.x))
-        assert len(all_neighbors) == 6
-
-    def test_ps3_returns_correct_num_neighbors(self):
-        """PS3 has n * (n - 1) elements.
-        But since we fix the first element as origin, it leads to
-        (n - 1) * (n - 2) = 12 in this case.
-        """
-
-        all_neighbors = list(local_search.ps3_gen(self.x))
-        assert len(all_neighbors) == 12
-
-
 class TestLocalSearch:
     @pytest.mark.parametrize(
         "distance_matrix, expected_distance",
@@ -64,12 +33,12 @@ class TestLocalSearch:
         self, distance_matrix, expected_distance
     ):
         """
-        The _setup outputs the same input if provided, together with
+        The setup outputs the same input if provided, together with
         its objective value
         """
 
         x0 = [0, 2, 3, 1, 4]
-        x, fx = local_search._setup(distance_matrix, x0)
+        x, fx = local_search.setup(distance_matrix, x0)
 
         assert x == x0
         assert fx == expected_distance
@@ -80,11 +49,11 @@ class TestLocalSearch:
     )
     def test_setup_return_random_valid_solution(self, distance_matrix):
         """
-        The _setup outputs a random valid permutation if no
+        The setup outputs a random valid permutation if no
         initial solution is provided
         """
 
-        x, fx = local_search._setup(distance_matrix)
+        x, fx = local_search.setup(distance_matrix)
 
         assert set(x) == set(range(distance_matrix.shape[0]))
         assert fx

--- a/tests/test_perturbation_schemes.py
+++ b/tests/test_perturbation_schemes.py
@@ -1,0 +1,32 @@
+from python_tsp.heuristics import perturbation_schemes
+
+
+class TestPerturbationSchemes:
+    x = [0, 1, 2, 3, 4]
+
+    def test_ps1_returns_correct_num_neighbors(self):
+        """PS1 has n - 1 swaps.
+        But since we fix the first element as origin, it leads to n - 2 = 3 in
+        this case.
+        """
+
+        all_neighbors = list(perturbation_schemes.ps1_gen(self.x))
+        assert len(all_neighbors) == 3
+
+    def test_ps2_returns_correct_num_neighbors(self):
+        """PS2 has n * (n - 1) / 2 swaps.
+        But since we fix the first element as origin, it leads to
+        (n - 1) * (n - 2) / 2 = 6 in this case.
+        """
+
+        all_neighbors = list(perturbation_schemes.ps2_gen(self.x))
+        assert len(all_neighbors) == 6
+
+    def test_ps3_returns_correct_num_neighbors(self):
+        """PS3 has n * (n - 1) elements.
+        But since we fix the first element as origin, it leads to
+        (n - 1) * (n - 2) = 12 in this case.
+        """
+
+        all_neighbors = list(perturbation_schemes.ps3_gen(self.x))
+        assert len(all_neighbors) == 12

--- a/tests/test_simulated_annealing.py
+++ b/tests/test_simulated_annealing.py
@@ -6,11 +6,13 @@ from .data import (
     distance_matrix1, distance_matrix2, distance_matrix3,
 )
 
+perturbation_schemes = ["ps1", "ps2", "ps3"]
+
 
 class TestSimulatedAnnealing:
     x = [0, 1, 2, 3, 4]
 
-    @pytest.mark.parametrize("scheme", ["ps1", "ps2", "ps3"])
+    @pytest.mark.parametrize("scheme", perturbation_schemes)
     def test_perturbation_generates_appropriate_neighbor(self, scheme):
         """
         Check if the generated neighbor has the same nodes as the input in any
@@ -27,7 +29,7 @@ class TestSimulatedAnnealing:
         "distance_matrix",
         [distance_matrix1, distance_matrix2, distance_matrix3]
     )
-    @pytest.mark.parametrize("scheme", ["ps1", "ps2", "ps3"])
+    @pytest.mark.parametrize("scheme", perturbation_schemes)
     def test_initial_temperature(self, distance_matrix, scheme):
         """
         The initial temperature is mostly random, so simply check if it is
@@ -35,7 +37,7 @@ class TestSimulatedAnnealing:
         """
 
         fx = compute_permutation_distance(distance_matrix, self.x)
-        temp = simulated_annealing.initial_temperature(
+        temp = simulated_annealing._initial_temperature(
             distance_matrix, self.x, fx, perturbation_scheme=scheme
         )
 
@@ -44,14 +46,14 @@ class TestSimulatedAnnealing:
     def test_acceptance_rule_improvement(self):
         """If fn < fx, the acceptance rule must return True"""
 
-        flag = simulated_annealing.acceptance_rule(2, 1, 1)
+        flag = simulated_annealing._acceptance_rule(2, 1, 1)
         assert flag
 
     @pytest.mark.parametrize(
         "distance_matrix",
         [distance_matrix1, distance_matrix2, distance_matrix3]
     )
-    @pytest.mark.parametrize("scheme", ["ps1", "ps2", "ps3"])
+    @pytest.mark.parametrize("scheme", perturbation_schemes)
     def test_simulated_annealing_solution(self, distance_matrix, scheme):
         """
         It is not possible to determine the returned solution, so this function


### PR DESCRIPTION
This PR moves the perturbation schemes to their own module, thus simplifying the other modules and allowing for the creation of other neighborhoods.