### PR TITLE
Add new perturbation schemes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ instance, to use a local search method:
    from python_tsp.heuristics import solve_tsp_local_search
 
    permutation, distance = solve_tsp_local_search(distance_matrix)
-   
+
 In this case there is generally no guarantee of optimality, but in this small
 instance the answer is normally a permutation with total distance 17 as well
 (notice in this case there are many permutations with the same optimal
@@ -150,7 +150,8 @@ You can also run all of these steps at once with the check-up bash script:
 
 .. code:: bash
 
-   bash ./.scripts/checkup_scripts.sh
+   ./.scripts/checkup_scripts.sh
+   bash ./.scripts/checkup_scripts.sh  # if the previous one fails
 
 Finally (and of course), make sure all tests pass and you get at least 95% of
 coverage:
@@ -158,3 +159,32 @@ coverage:
 .. code:: bash
 
   poetry run pytest --cov=. --cov-report=term-missing --cov-fail-under=95 tests/
+
+
+Release Notes and Changelog
+===========================
+
+Release 0.1.1
+-------------
+
+Improved Python versions support.
+
+Python support:
+
+* Python >= 3.6
+
+
+Release 0.1.0
+-------------
+
+Initial version. Support for the following solvers:
+
+* Exact (Brute force and Dynamic Programming);
+* Heuristics (Local Search and Simulated Annealing).
+
+The local search-based algorithms can be run with neighborhoods PS1, PS2 and
+PS3.
+
+Python support:
+
+* Python >= 3.8

--- a/poetry.lock
+++ b/poetry.lock
@@ -216,18 +216,18 @@ python-versions = "*"
 
 [[package]]
 name = "jedi"
-version = "0.18.0"
+version = "0.17.2"
 description = "An autocompletion tool for Python that can be used for text editors."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
-parso = ">=0.8.0,<0.9.0"
+parso = ">=0.7.0,<0.8.0"
 
 [package.extras]
-qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
-testing = ["Django (<3.1)", "colorama", "docopt", "pytest (<6.0.0)"]
+qa = ["flake8 (==3.7.9)"]
+testing = ["Django (<3.1)", "colorama", "docopt", "pytest (>=3.9.0,<5.0.0)"]
 
 [[package]]
 name = "jinja2"
@@ -312,15 +312,14 @@ pyparsing = ">=2.0.2"
 
 [[package]]
 name = "parso"
-version = "0.8.1"
+version = "0.7.1"
 description = "A Python Parser"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.extras]
-qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
-testing = ["docopt", "pytest (<6.0.0)"]
+testing = ["docopt", "pytest (>=3.0.7)"]
 
 [[package]]
 name = "pexpect"
@@ -672,7 +671,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "4dc247bede31b592a6b21d7a650859a5aa7b781d76fbc93224c4df5712e93ddd"
+content-hash = "8d2994129931afb74e119b70372ed2579d8185a1752f27d78c2f8e886e4bc82a"
 
 [metadata.files]
 alabaster = [
@@ -802,8 +801,8 @@ ipython-genutils = [
     {file = "ipython_genutils-0.2.0.tar.gz", hash = "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"},
 ]
 jedi = [
-    {file = "jedi-0.18.0-py2.py3-none-any.whl", hash = "sha256:18456d83f65f400ab0c2d3319e48520420ef43b23a086fdc05dff34132f0fb93"},
-    {file = "jedi-0.18.0.tar.gz", hash = "sha256:92550a404bad8afed881a137ec9a461fed49eca661414be45059329614ed0707"},
+    {file = "jedi-0.17.2-py2.py3-none-any.whl", hash = "sha256:98cc583fa0f2f8304968199b01b6b4b94f469a1f4a74c1560506ca2a211378b5"},
+    {file = "jedi-0.17.2.tar.gz", hash = "sha256:86ed7d9b750603e4ba582ea8edc678657fb4007894a12bcf6f4bb97892f31d20"},
 ]
 jinja2 = [
     {file = "Jinja2-2.11.3-py2.py3-none-any.whl", hash = "sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419"},
@@ -913,8 +912,8 @@ packaging = [
     {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
 ]
 parso = [
-    {file = "parso-0.8.1-py2.py3-none-any.whl", hash = "sha256:15b00182f472319383252c18d5913b69269590616c947747bc50bf4ac768f410"},
-    {file = "parso-0.8.1.tar.gz", hash = "sha256:8519430ad07087d4c997fda3a7918f7cfa27cb58972a8c89c2a0295a1c940e9e"},
+    {file = "parso-0.7.1-py2.py3-none-any.whl", hash = "sha256:97218d9159b2520ff45eb78028ba8b50d2bc61dcc062a9682666f2dc4bd331ea"},
+    {file = "parso-0.7.1.tar.gz", hash = "sha256:caba44724b994a8a5e086460bb212abc5a8bc46951bf4a9a1210745953622eb9"},
 ]
 pexpect = [
     {file = "pexpect-4.8.0-py2.py3-none-any.whl", hash = "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "python_tsp"
-version = "0.1.1"
+version = "0.2.0"
 description = "Simple library to solve the Traveling Salesperson Problem in pure Python."
 readme = "README_pypi.rst"
 authors = ["Fillipe Goulart <fillipe.gsm@tutanota.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ mypy = "^0.782"
 autopep8 = "^1.5.3"
 flake8 = "^3.8.3"
 pytest-cov = "^2.10.1"
+jedi = "<0.18"
 
 [tool.autopep8]
 max_line_length = 79

--- a/python_tsp/heuristics/local_search.py
+++ b/python_tsp/heuristics/local_search.py
@@ -1,6 +1,6 @@
 """Simple local search solver"""
+from random import sample
 from typing import List, Optional, Tuple
-import random
 
 import numpy as np
 
@@ -95,7 +95,7 @@ def setup(
 
     if not x0:
         n = distance_matrix.shape[0]  # number of nodes
-        x0 = random.sample(range(n), n)
+        x0 = [0] + sample(range(1, n), n - 1)  # 0 is always the first
 
     fx0 = compute_permutation_distance(distance_matrix, x0)
     return x0, fx0

--- a/python_tsp/heuristics/local_search.py
+++ b/python_tsp/heuristics/local_search.py
@@ -1,10 +1,11 @@
-"""Module with a 2-opt local search solver"""
-from typing import Callable, Dict, Generator, List, Optional, Tuple
+"""Simple local search solver"""
+from typing import List, Optional, Tuple
 import random
 
 import numpy as np
 
 from python_tsp.utils import compute_permutation_distance
+from python_tsp.heuristics.perturbation_schemes import neighborhood_gen
 
 
 def solve_tsp_local_search(
@@ -52,13 +53,7 @@ def solve_tsp_local_search(
     International Journal of Electrical Power & Energy Systems 101 (2018):
     339-355.
     """
-    neighborhood_gen: Dict[
-        str, Callable[[List[int]], Generator[List[int], List[int], None]]
-    ] = {
-        "ps1": ps1_gen, "ps2": ps2_gen, "ps3": ps3_gen,
-    }
-
-    x, fx = _setup(distance_matrix, x0)
+    x, fx = setup(distance_matrix, x0)
 
     improvement = True
     while improvement:
@@ -73,7 +68,7 @@ def solve_tsp_local_search(
     return x, fx
 
 
-def _setup(
+def setup(
     distance_matrix: np.ndarray, x0: Optional[List] = None
 ) -> Tuple[List[int], float]:
     """Return initial solution and its objective value
@@ -104,47 +99,3 @@ def _setup(
 
     fx0 = compute_permutation_distance(distance_matrix, x0)
     return x0, fx0
-
-
-def ps1_gen(x: List[int]) -> Generator[List[int], List[int], None]:
-    """PS1 perturbation scheme: Swap two adjacent terms
-    This scheme has at most n - 1 swaps.
-    """
-
-    n = len(x)
-    i_range = range(1, n - 1)
-    for i in random.sample(i_range, len(i_range)):
-        xn = x.copy()
-        xn[i], xn[i + 1] = x[i + 1], xn[i]
-        yield xn
-
-
-def ps2_gen(x: List[int]) -> Generator[List[int], List[int], None]:
-    """PS2 perturbation scheme: Swap any two elements
-    This scheme has n * (n - 1) / 2 swaps.
-    """
-
-    n = len(x)
-    i_range = range(1, n - 1)
-    for i in random.sample(i_range, len(i_range)):
-        j_range = range(i + 1, n)
-        for j in random.sample(j_range, len(j_range)):
-            xn = x.copy()
-            xn[i], xn[j] = xn[j], xn[i]
-            yield xn
-
-
-def ps3_gen(x: List[int]) -> Generator[List[int], List[int], None]:
-    """PS3 perturbation scheme: A single term is moved
-    This scheme has n * (n - 1) swaps.
-    """
-
-    n = len(x)
-    i_range = range(1, n)
-    for i in random.sample(i_range, len(i_range)):
-        j_range = [j for j in range(1, n) if j != i]
-        for j in random.sample(j_range, len(j_range)):
-            xn = x.copy()
-            node = xn.pop(i)
-            xn.insert(j, node)
-            yield xn

--- a/python_tsp/heuristics/local_search.py
+++ b/python_tsp/heuristics/local_search.py
@@ -24,9 +24,8 @@ def solve_tsp_local_search(
     x0
         Initial permutation. If not provided, it uses a random value
 
-    perturbation_scheme {"ps1", "ps2", "ps3", "ps4", "ps5", ["ps6"]}
-        Mechanism used to generate new solutions. Defaults to PS6. See [1] for
-        a quick explanation on these schemes.
+    perturbation_scheme {"ps1", "ps2", "ps3", "ps4", "ps5", ["ps6"], "two_opt"}
+        Mechanism used to generate new solutions. Defaults to PS6.
 
     Returns
     -------
@@ -45,13 +44,6 @@ def solve_tsp_local_search(
             and stop;
         3. Repeat step 2 until all neighbors of `x` are tried and there is no
         improvement. Return `x`, `fx` as solution.
-
-    References
-    ----------
-    [1] Goulart, Fillipe, et al. "Permutation-based optimization for the load
-    restoration problem with improved time estimation of maneuvers."
-    International Journal of Electrical Power & Energy Systems 101 (2018):
-    339-355.
     """
     x, fx = setup(distance_matrix, x0)
 

--- a/python_tsp/heuristics/local_search.py
+++ b/python_tsp/heuristics/local_search.py
@@ -11,7 +11,7 @@ from python_tsp.heuristics.perturbation_schemes import neighborhood_gen
 def solve_tsp_local_search(
     distance_matrix: np.ndarray,
     x0: Optional[List[int]] = None,
-    perturbation_scheme: str = "ps3",
+    perturbation_scheme: str = "ps6",
 ) -> Tuple[List, float]:
     """Solve a TSP problem with a local search heuristic
 
@@ -24,14 +24,14 @@ def solve_tsp_local_search(
     x0
         Initial permutation. If not provided, it uses a random value
 
-    perturbation_scheme {"ps1", "ps2", ["ps3"]}
-        Mechanism used to generate new solutions. Defaults to PS3. See [1] for
+    perturbation_scheme {"ps1", "ps2", "ps3", "ps4", "ps5", ["ps6"]}
+        Mechanism used to generate new solutions. Defaults to PS6. See [1] for
         a quick explanation on these schemes.
 
     Returns
     -------
-    A permutation of nodes from 0 to n that produces the least total distance
-    obtained (not necessarily optimal).
+    A permutation of nodes from 0 to n - 1 that produces the least total
+    distance obtained (not necessarily optimal).
 
     The total distance the returned permutation produces.
 

--- a/python_tsp/heuristics/perturbation_schemes.py
+++ b/python_tsp/heuristics/perturbation_schemes.py
@@ -1,0 +1,61 @@
+"""Perturbation schemes used in local search-based algorithms.
+The functions here should receive a permutation list with numbers from 0 to `n`
+and return a generator with all neighbors of this permutation.
+The neighbors should preferably be randomized to be used in Simulated
+Annealing, which samples a single neighbor at a time.
+"""
+from typing import Callable, Dict, Generator, List
+
+import random
+
+
+def ps1_gen(x: List[int]) -> Generator[List[int], List[int], None]:
+    """PS1 perturbation scheme: Swap two adjacent terms
+    This scheme has at most n - 1 swaps.
+    """
+
+    n = len(x)
+    i_range = range(1, n - 1)
+    for i in random.sample(i_range, len(i_range)):
+        xn = x.copy()
+        xn[i], xn[i + 1] = x[i + 1], xn[i]
+        yield xn
+
+
+def ps2_gen(x: List[int]) -> Generator[List[int], List[int], None]:
+    """PS2 perturbation scheme: Swap any two elements
+    This scheme has n * (n - 1) / 2 swaps.
+    """
+
+    n = len(x)
+    i_range = range(1, n - 1)
+    for i in random.sample(i_range, len(i_range)):
+        j_range = range(i + 1, n)
+        for j in random.sample(j_range, len(j_range)):
+            xn = x.copy()
+            xn[i], xn[j] = xn[j], xn[i]
+            yield xn
+
+
+def ps3_gen(x: List[int]) -> Generator[List[int], List[int], None]:
+    """PS3 perturbation scheme: A single term is moved
+    This scheme has n * (n - 1) swaps.
+    """
+
+    n = len(x)
+    i_range = range(1, n)
+    for i in random.sample(i_range, len(i_range)):
+        j_range = [j for j in range(1, n) if j != i]
+        for j in random.sample(j_range, len(j_range)):
+            xn = x.copy()
+            node = xn.pop(i)
+            xn.insert(j, node)
+            yield xn
+
+
+# Mapping with all possible neighborhood generators in this module
+neighborhood_gen: Dict[
+    str, Callable[[List[int]], Generator[List[int], List[int], None]]
+] = {
+    "ps1": ps1_gen, "ps2": ps2_gen, "ps3": ps3_gen,
+}

--- a/python_tsp/heuristics/perturbation_schemes.py
+++ b/python_tsp/heuristics/perturbation_schemes.py
@@ -3,6 +3,14 @@ The functions here should receive a permutation list with numbers from 0 to `n`
 and return a generator with all neighbors of this permutation.
 The neighbors should preferably be randomized to be used in Simulated
 Annealing, which samples a single neighbor at a time.
+
+References
+----------
+.. [1] Goulart, Fillipe, et al. "Permutation-based optimization for the load
+    restoration problem with improved time estimation of maneuvers."
+    International Journal of Electrical Power & Energy Systems 101 (2018):
+    339-355.
+.. [2] 2-opt: https://en.wikipedia.org/wiki/2-opt
 """
 from random import sample
 from typing import Callable, Dict, Generator, List
@@ -17,7 +25,7 @@ def ps1_gen(x: List[int]) -> Generator[List[int], List[int], None]:
     i_range = range(1, n - 1)
     for i in sample(i_range, len(i_range)):
         xn = x.copy()
-        xn[i], xn[i + 1] = x[i + 1], xn[i]
+        xn[i], xn[i + 1] = xn[i + 1], xn[i]
         yield xn
 
 
@@ -64,9 +72,9 @@ def ps4_gen(x: List[int]) -> Generator[List[int], List[int], None]:
             for k in sample(k_range, len(k_range)):
                 xn = x.copy()
                 if k < i:
-                    xn = x[:k] + x[i:j] + x[k:i] + x[j:]
+                    xn = xn[:k] + xn[i:j] + xn[k:i] + xn[j:]
                 else:
-                    xn = x[:i] + x[j:k] + x[i:j] + x[k:]
+                    xn = xn[:i] + xn[j:k] + xn[i:j] + xn[k:]
                 yield xn
 
 
@@ -95,10 +103,22 @@ def ps6_gen(x: List[int]) -> Generator[List[int], List[int], None]:
             for k in sample(k_range, len(k_range)):
                 xn = x.copy()
                 if k < i:
-                    xn = x[:k] + list(reversed(x[i:j])) + x[k:i] + x[j:]
+                    xn = xn[:k] + list(reversed(xn[i:j])) + xn[k:i] + xn[j:]
                 else:
-                    xn = x[:i] + x[j:k] + list(reversed(x[i:j])) + x[k:]
+                    xn = xn[:i] + xn[j:k] + list(reversed(xn[i:j])) + xn[k:]
                 yield xn
+
+
+def two_opt_gen(x: List[int]) -> Generator[List[int], List[int], None]:
+    """2-opt perturbation scheme [2]"""
+    n = len(x)
+    i_range = range(2, n)
+    for i in i_range:
+        j_range = range(i + 1, n + 1)
+        for j in j_range:
+            xn = x.copy()
+            xn = xn[:i-1] + list(reversed(xn[i-1:j])) + xn[j:]
+            yield xn
 
 
 # Mapping with all possible neighborhood generators in this module
@@ -111,4 +131,5 @@ neighborhood_gen: Dict[
     "ps4": ps4_gen,
     "ps5": ps5_gen,
     "ps6": ps6_gen,
+    "two_opt": two_opt_gen,
 }

--- a/python_tsp/heuristics/perturbation_schemes.py
+++ b/python_tsp/heuristics/perturbation_schemes.py
@@ -17,7 +17,7 @@ from typing import Callable, Dict, Generator, List
 
 
 def ps1_gen(x: List[int]) -> Generator[List[int], List[int], None]:
-    """PS1 perturbation scheme: Swap two adjacent terms
+    """PS1 perturbation scheme: Swap two adjacent terms [1]
     This scheme has at most n - 1 swaps.
     """
 
@@ -30,7 +30,7 @@ def ps1_gen(x: List[int]) -> Generator[List[int], List[int], None]:
 
 
 def ps2_gen(x: List[int]) -> Generator[List[int], List[int], None]:
-    """PS2 perturbation scheme: Swap any two elements
+    """PS2 perturbation scheme: Swap any two elements [1]
     This scheme has n * (n - 1) / 2 swaps.
     """
 
@@ -45,7 +45,7 @@ def ps2_gen(x: List[int]) -> Generator[List[int], List[int], None]:
 
 
 def ps3_gen(x: List[int]) -> Generator[List[int], List[int], None]:
-    """PS3 perturbation scheme: A single term is moved
+    """PS3 perturbation scheme: A single term is moved [1]
     This scheme has n * (n - 1) swaps.
     """
 
@@ -61,7 +61,7 @@ def ps3_gen(x: List[int]) -> Generator[List[int], List[int], None]:
 
 
 def ps4_gen(x: List[int]) -> Generator[List[int], List[int], None]:
-    """PS4 perturbation scheme: A subsequence is moved"""
+    """PS4 perturbation scheme: A subsequence is moved [1]"""
 
     n = len(x)
     i_range = range(1, n)
@@ -79,7 +79,7 @@ def ps4_gen(x: List[int]) -> Generator[List[int], List[int], None]:
 
 
 def ps5_gen(x: List[int]) -> Generator[List[int], List[int], None]:
-    """PS5 perturbation scheme: A subsequence is reversed"""
+    """PS5 perturbation scheme: A subsequence is reversed [1]"""
 
     n = len(x)
     i_range = range(1, n)
@@ -92,7 +92,7 @@ def ps5_gen(x: List[int]) -> Generator[List[int], List[int], None]:
 
 
 def ps6_gen(x: List[int]) -> Generator[List[int], List[int], None]:
-    """PS6 perturbation scheme: A subsequence is reversed and moved"""
+    """PS6 perturbation scheme: A subsequence is reversed and moved [1]"""
 
     n = len(x)
     i_range = range(1, n)

--- a/python_tsp/heuristics/perturbation_schemes.py
+++ b/python_tsp/heuristics/perturbation_schemes.py
@@ -113,11 +113,11 @@ def two_opt_gen(x: List[int]) -> Generator[List[int], List[int], None]:
     """2-opt perturbation scheme [2]"""
     n = len(x)
     i_range = range(2, n)
-    for i in i_range:
+    for i in sample(i_range, len(i_range)):
         j_range = range(i + 1, n + 1)
-        for j in j_range:
+        for j in sample(j_range, len(j_range)):
             xn = x.copy()
-            xn = xn[:i-1] + list(reversed(xn[i-1:j])) + xn[j:]
+            xn = xn[:i - 1] + list(reversed(xn[i - 1:j])) + xn[j:]
             yield xn
 
 

--- a/python_tsp/heuristics/perturbation_schemes.py
+++ b/python_tsp/heuristics/perturbation_schemes.py
@@ -4,9 +4,8 @@ and return a generator with all neighbors of this permutation.
 The neighbors should preferably be randomized to be used in Simulated
 Annealing, which samples a single neighbor at a time.
 """
+from random import sample
 from typing import Callable, Dict, Generator, List
-
-import random
 
 
 def ps1_gen(x: List[int]) -> Generator[List[int], List[int], None]:
@@ -16,7 +15,7 @@ def ps1_gen(x: List[int]) -> Generator[List[int], List[int], None]:
 
     n = len(x)
     i_range = range(1, n - 1)
-    for i in random.sample(i_range, len(i_range)):
+    for i in sample(i_range, len(i_range)):
         xn = x.copy()
         xn[i], xn[i + 1] = x[i + 1], xn[i]
         yield xn
@@ -29,9 +28,9 @@ def ps2_gen(x: List[int]) -> Generator[List[int], List[int], None]:
 
     n = len(x)
     i_range = range(1, n - 1)
-    for i in random.sample(i_range, len(i_range)):
+    for i in sample(i_range, len(i_range)):
         j_range = range(i + 1, n)
-        for j in random.sample(j_range, len(j_range)):
+        for j in sample(j_range, len(j_range)):
             xn = x.copy()
             xn[i], xn[j] = xn[j], xn[i]
             yield xn
@@ -44,18 +43,72 @@ def ps3_gen(x: List[int]) -> Generator[List[int], List[int], None]:
 
     n = len(x)
     i_range = range(1, n)
-    for i in random.sample(i_range, len(i_range)):
+    for i in sample(i_range, len(i_range)):
         j_range = [j for j in range(1, n) if j != i]
-        for j in random.sample(j_range, len(j_range)):
+        for j in sample(j_range, len(j_range)):
             xn = x.copy()
             node = xn.pop(i)
             xn.insert(j, node)
             yield xn
 
 
+def ps4_gen(x: List[int]) -> Generator[List[int], List[int], None]:
+    """PS4 perturbation scheme: A subsequence is moved"""
+
+    n = len(x)
+    i_range = range(1, n)
+    for i in sample(i_range, len(i_range)):
+        j_range = range(i + 1, n + 1)
+        for j in sample(j_range, len(j_range)):
+            k_range = [k for k in range(1, n + 1) if k not in range(i, j + 1)]
+            for k in sample(k_range, len(k_range)):
+                xn = x.copy()
+                if k < i:
+                    xn = x[:k] + x[i:j] + x[k:i] + x[j:]
+                else:
+                    xn = x[:i] + x[j:k] + x[i:j] + x[k:]
+                yield xn
+
+
+def ps5_gen(x: List[int]) -> Generator[List[int], List[int], None]:
+    """PS5 perturbation scheme: A subsequence is reversed"""
+
+    n = len(x)
+    i_range = range(1, n)
+    for i in sample(i_range, len(i_range)):
+        j_range = range(i + 2, n + 1)
+        for j in sample(j_range, len(j_range)):
+            xn = x.copy()
+            xn = xn[:i] + list(reversed(xn[i:j])) + xn[j:]
+            yield xn
+
+
+def ps6_gen(x: List[int]) -> Generator[List[int], List[int], None]:
+    """PS6 perturbation scheme: A subsequence is reversed and moved"""
+
+    n = len(x)
+    i_range = range(1, n)
+    for i in sample(i_range, len(i_range)):
+        j_range = range(i + 1, n + 1)
+        for j in sample(j_range, len(j_range)):
+            k_range = [k for k in range(1, n + 1) if k not in range(i, j + 1)]
+            for k in sample(k_range, len(k_range)):
+                xn = x.copy()
+                if k < i:
+                    xn = x[:k] + list(reversed(x[i:j])) + x[k:i] + x[j:]
+                else:
+                    xn = x[:i] + x[j:k] + list(reversed(x[i:j])) + x[k:]
+                yield xn
+
+
 # Mapping with all possible neighborhood generators in this module
 neighborhood_gen: Dict[
     str, Callable[[List[int]], Generator[List[int], List[int], None]]
 ] = {
-    "ps1": ps1_gen, "ps2": ps2_gen, "ps3": ps3_gen,
+    "ps1": ps1_gen,
+    "ps2": ps2_gen,
+    "ps3": ps3_gen,
+    "ps4": ps4_gen,
+    "ps5": ps5_gen,
+    "ps6": ps6_gen,
 }

--- a/python_tsp/heuristics/simulated_annealing.py
+++ b/python_tsp/heuristics/simulated_annealing.py
@@ -26,9 +26,8 @@ def solve_tsp_simulated_annealing(
     x0
         Initial permutation. If not provided, it uses a random value
 
-    perturbation_scheme {"ps1", "ps2", "ps3", "ps4", "ps5", ["ps6"]}
-        Mechanism used to generate new solutions. Defaults to PS6. See [1] for
-        a quick explanation on these schemes.
+    perturbation_scheme {"ps1", "ps2", "ps3", "ps4", "ps5", ["ps6"], "two_opt"}
+        Mechanism used to generate new solutions. Defaults to PS6.
 
     alpha
         Reduction factor (``alpha`` < 1) used to reduce the temperature. As a
@@ -51,11 +50,6 @@ def solve_tsp_simulated_annealing(
     ----------
     [1] Dréo, Johann, et al. Metaheuristics for hard optimization: methods and
     case studies. Springer Science & Business Media, 2006.
-
-    [2] Goulart, Fillipe, et al. "Permutation-based optimization for the load
-    restoration problem with improved time estimation of maneuvers."
-    International Journal of Electrical Power & Energy Systems 101 (2018):
-    339-355.
     """
 
     x, fx = setup(distance_matrix, x0)

--- a/python_tsp/heuristics/simulated_annealing.py
+++ b/python_tsp/heuristics/simulated_annealing.py
@@ -10,7 +10,7 @@ from python_tsp.utils import compute_permutation_distance
 def solve_tsp_simulated_annealing(
     distance_matrix: np.ndarray,
     x0: Optional[List[int]] = None,
-    perturbation_scheme: str = "ps3",
+    perturbation_scheme: str = "ps6",
     alpha: float = 0.9,
     verbose: bool = False,
 ) -> Tuple[List, float]:
@@ -26,8 +26,8 @@ def solve_tsp_simulated_annealing(
     x0
         Initial permutation. If not provided, it uses a random value
 
-    perturbation_scheme {"ps1", "ps2", ["ps3"]}
-        Mechanism used to generate new solutions. Defaults to PS3. See [2] for
+    perturbation_scheme {"ps1", "ps2", "ps3", "ps4", "ps5", ["ps6"]}
+        Mechanism used to generate new solutions. Defaults to PS6. See [1] for
         a quick explanation on these schemes.
 
     alpha
@@ -42,8 +42,8 @@ def solve_tsp_simulated_annealing(
 
     Returns
     -------
-    A permutation of nodes from 0 to n that produces the least total distance
-    obtained (not necessarily optimal).
+    A permutation of nodes from 0 to n - 1 that produces the least total
+    distance obtained (not necessarily optimal).
 
     The total distance the returned permutation produces.
 
@@ -100,7 +100,7 @@ def _initial_temperature(
     distance_matrix: np.ndarray,
     x: List[int],
     fx: float,
-    perturbation_scheme: str = "ps3"
+    perturbation_scheme: str,
 ) -> float:
     """Compute initial temperature
     Instead of relying on problem-dependent parameters, this function estimates
@@ -135,7 +135,7 @@ def _initial_temperature(
     return -dfx_mean / np.log(tau0)
 
 
-def _perturbation(x: List[int], perturbation_scheme: str = "ps3"):
+def _perturbation(x: List[int], perturbation_scheme: str):
     """Generate a random neighbor of a current solution ``x``
     In this case, we can use the generators created in the `local_search`
     module, and pick the first solution. Since the neighborhood is randomized,

--- a/python_tsp/heuristics/simulated_annealing.py
+++ b/python_tsp/heuristics/simulated_annealing.py
@@ -1,8 +1,9 @@
-from typing import Callable, Dict, Generator, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 
-from python_tsp.heuristics import local_search
+from python_tsp.heuristics.perturbation_schemes import neighborhood_gen
+from python_tsp.heuristics.local_search import setup
 from python_tsp.utils import compute_permutation_distance
 
 
@@ -57,7 +58,7 @@ def solve_tsp_simulated_annealing(
     339-355.
     """
 
-    x, fx = local_search._setup(distance_matrix, x0)
+    x, fx = setup(distance_matrix, x0)
     temp = initial_temperature(distance_matrix, x, fx, perturbation_scheme)
 
     n = len(x)
@@ -140,14 +141,6 @@ def _perturbation(x: List[int], perturbation_scheme: str = "ps3"):
     module, and pick the first solution. Since the neighborhood is randomized,
     it is the same as creating a random perturbation.
     """
-    neighborhood_gen: Dict[
-        str, Callable[[List[int]], Generator[List[int], List[int], None]]
-    ] = {
-        "ps1": local_search.ps1_gen,
-        "ps2": local_search.ps2_gen,
-        "ps3": local_search.ps3_gen,
-    }
-
     return next(neighborhood_gen[perturbation_scheme](x))
 
 

--- a/python_tsp/heuristics/simulated_annealing.py
+++ b/python_tsp/heuristics/simulated_annealing.py
@@ -59,7 +59,7 @@ def solve_tsp_simulated_annealing(
     """
 
     x, fx = setup(distance_matrix, x0)
-    temp = initial_temperature(distance_matrix, x, fx, perturbation_scheme)
+    temp = _initial_temperature(distance_matrix, x, fx, perturbation_scheme)
 
     n = len(x)
     k_inner_min = 12 * n  # min inner iterations
@@ -72,7 +72,7 @@ def solve_tsp_simulated_annealing(
             xn = _perturbation(x, perturbation_scheme)
             fn = compute_permutation_distance(distance_matrix, xn)
 
-            if acceptance_rule(fx, fn, temp):
+            if _acceptance_rule(fx, fn, temp):
                 x, fx = xn, fn
                 k_accepted += 1
                 k_noimprovements = 0
@@ -96,7 +96,7 @@ def solve_tsp_simulated_annealing(
     return x, fx
 
 
-def initial_temperature(
+def _initial_temperature(
     distance_matrix: np.ndarray,
     x: List[int],
     fx: float,
@@ -144,7 +144,7 @@ def _perturbation(x: List[int], perturbation_scheme: str = "ps3"):
     return next(neighborhood_gen[perturbation_scheme](x))
 
 
-def acceptance_rule(fx: float, fn: float, temp: float) -> bool:
+def _acceptance_rule(fx: float, fn: float, temp: float) -> bool:
     """Metropolis acceptance rule"""
 
     dfx = fn - fx

--- a/tests/test_local_search.py
+++ b/tests/test_local_search.py
@@ -9,7 +9,7 @@ from .data import (
 )
 
 
-perturbation_schemes = ["ps1", "ps2", "ps3", "ps4", "ps5", "ps6"]
+perturbation_schemes = ["ps1", "ps2", "ps3", "ps4", "ps5", "ps6", "two_opt"]
 
 
 class TestImportModule:

--- a/tests/test_local_search.py
+++ b/tests/test_local_search.py
@@ -9,6 +9,9 @@ from .data import (
 )
 
 
+perturbation_schemes = ["ps1", "ps2", "ps3", "ps4", "ps5", "ps6"]
+
+
 class TestImportModule:
     def test_can_import_local_search_solver(self):
         """
@@ -58,7 +61,7 @@ class TestLocalSearch:
         assert set(x) == set(range(distance_matrix.shape[0]))
         assert fx
 
-    @pytest.mark.parametrize("scheme", ["ps1", "ps2", "ps3"])
+    @pytest.mark.parametrize("scheme", perturbation_schemes)
     @pytest.mark.parametrize(
         "distance_matrix",
         [distance_matrix1, distance_matrix2, distance_matrix3]
@@ -79,7 +82,7 @@ class TestLocalSearch:
 
         assert fopt < fx
 
-    @pytest.mark.parametrize("scheme", ["ps1", "ps2", "ps3"])
+    @pytest.mark.parametrize("scheme", perturbation_schemes)
     @pytest.mark.parametrize(
         "distance_matrix, optimal_permutation, optimal_distance",
         [

--- a/tests/test_local_search.py
+++ b/tests/test_local_search.py
@@ -20,37 +20,6 @@ class TestImportModule:
         )
 
 
-class TestPerturbationSchemes:
-    x = [0, 1, 2, 3, 4]
-
-    def test_ps1_returns_correct_num_neighbors(self):
-        """PS1 has n - 1 swaps.
-        But since we fix the first element as origin, it leads to n - 2 = 3 in
-        this case.
-        """
-
-        all_neighbors = list(local_search.ps1_gen(self.x))
-        assert len(all_neighbors) == 3
-
-    def test_ps2_returns_correct_num_neighbors(self):
-        """PS2 has n * (n - 1) / 2 swaps.
-        But since we fix the first element as origin, it leads to
-        (n - 1) * (n - 2) / 2 = 6 in this case.
-        """
-
-        all_neighbors = list(local_search.ps2_gen(self.x))
-        assert len(all_neighbors) == 6
-
-    def test_ps3_returns_correct_num_neighbors(self):
-        """PS3 has n * (n - 1) elements.
-        But since we fix the first element as origin, it leads to
-        (n - 1) * (n - 2) = 12 in this case.
-        """
-
-        all_neighbors = list(local_search.ps3_gen(self.x))
-        assert len(all_neighbors) == 12
-
-
 class TestLocalSearch:
     @pytest.mark.parametrize(
         "distance_matrix, expected_distance",
@@ -64,12 +33,12 @@ class TestLocalSearch:
         self, distance_matrix, expected_distance
     ):
         """
-        The _setup outputs the same input if provided, together with
+        The setup outputs the same input if provided, together with
         its objective value
         """
 
         x0 = [0, 2, 3, 1, 4]
-        x, fx = local_search._setup(distance_matrix, x0)
+        x, fx = local_search.setup(distance_matrix, x0)
 
         assert x == x0
         assert fx == expected_distance
@@ -80,11 +49,11 @@ class TestLocalSearch:
     )
     def test_setup_return_random_valid_solution(self, distance_matrix):
         """
-        The _setup outputs a random valid permutation if no
+        The setup outputs a random valid permutation if no
         initial solution is provided
         """
 
-        x, fx = local_search._setup(distance_matrix)
+        x, fx = local_search.setup(distance_matrix)
 
         assert set(x) == set(range(distance_matrix.shape[0]))
         assert fx

--- a/tests/test_perturbation_schemes.py
+++ b/tests/test_perturbation_schemes.py
@@ -1,0 +1,32 @@
+from python_tsp.heuristics import perturbation_schemes
+
+
+class TestPerturbationSchemes:
+    x = [0, 1, 2, 3, 4]
+
+    def test_ps1_returns_correct_num_neighbors(self):
+        """PS1 has n - 1 swaps.
+        But since we fix the first element as origin, it leads to n - 2 = 3 in
+        this case.
+        """
+
+        all_neighbors = list(perturbation_schemes.ps1_gen(self.x))
+        assert len(all_neighbors) == 3
+
+    def test_ps2_returns_correct_num_neighbors(self):
+        """PS2 has n * (n - 1) / 2 swaps.
+        But since we fix the first element as origin, it leads to
+        (n - 1) * (n - 2) / 2 = 6 in this case.
+        """
+
+        all_neighbors = list(perturbation_schemes.ps2_gen(self.x))
+        assert len(all_neighbors) == 6
+
+    def test_ps3_returns_correct_num_neighbors(self):
+        """PS3 has n * (n - 1) elements.
+        But since we fix the first element as origin, it leads to
+        (n - 1) * (n - 2) = 12 in this case.
+        """
+
+        all_neighbors = list(perturbation_schemes.ps3_gen(self.x))
+        assert len(all_neighbors) == 12

--- a/tests/test_perturbation_schemes.py
+++ b/tests/test_perturbation_schemes.py
@@ -54,3 +54,10 @@ class TestPerturbationSchemes:
 
         all_neighbors = list(perturbation_schemes.ps6_gen(self.x))
         assert len(all_neighbors) == 20
+
+    def test_two_opt_returns_correct_num_neighbors(self):
+        """2-top has the same number of perturbations as PS5.
+        Thus, in this case with 4 items (the one fixed), we get 6 neighbors.
+        """
+        all_neighbors = list(perturbation_schemes.two_opt_gen(self.x))
+        assert len(all_neighbors) == 6

--- a/tests/test_perturbation_schemes.py
+++ b/tests/test_perturbation_schemes.py
@@ -30,3 +30,27 @@ class TestPerturbationSchemes:
 
         all_neighbors = list(perturbation_schemes.ps3_gen(self.x))
         assert len(all_neighbors) == 12
+
+    def test_ps4_returns_correct_num_neighbors(self):
+        """PS4 is more intricate. Doing by hand, the total perturbations here
+        is equal to 20, so its neighborhood size is larger than PS3.
+        """
+
+        all_neighbors = list(perturbation_schemes.ps4_gen(self.x))
+        assert len(all_neighbors) == 20
+
+    def test_ps5_returns_correct_num_neighbors(self):
+        """PS5 has sum_{i=1}^{n} (n - i) elements.
+        In this case with 4 items (the first one is fixed), we get 6 neighbors
+        """
+
+        all_neighbors = list(perturbation_schemes.ps5_gen(self.x))
+        assert len(all_neighbors) == 6
+
+    def test_ps6_returns_correct_num_neighbors(self):
+        """PS6 is intricate as PS4, with the same number of neighbors.
+        Here, it is equal to 20 as well.
+        """
+
+        all_neighbors = list(perturbation_schemes.ps6_gen(self.x))
+        assert len(all_neighbors) == 20

--- a/tests/test_simulated_annealing.py
+++ b/tests/test_simulated_annealing.py
@@ -6,11 +6,13 @@ from .data import (
     distance_matrix1, distance_matrix2, distance_matrix3,
 )
 
+perturbation_schemes = ["ps1", "ps2", "ps3"]
+
 
 class TestSimulatedAnnealing:
     x = [0, 1, 2, 3, 4]
 
-    @pytest.mark.parametrize("scheme", ["ps1", "ps2", "ps3"])
+    @pytest.mark.parametrize("scheme", perturbation_schemes)
     def test_perturbation_generates_appropriate_neighbor(self, scheme):
         """
         Check if the generated neighbor has the same nodes as the input in any
@@ -27,7 +29,7 @@ class TestSimulatedAnnealing:
         "distance_matrix",
         [distance_matrix1, distance_matrix2, distance_matrix3]
     )
-    @pytest.mark.parametrize("scheme", ["ps1", "ps2", "ps3"])
+    @pytest.mark.parametrize("scheme", perturbation_schemes)
     def test_initial_temperature(self, distance_matrix, scheme):
         """
         The initial temperature is mostly random, so simply check if it is
@@ -35,7 +37,7 @@ class TestSimulatedAnnealing:
         """
 
         fx = compute_permutation_distance(distance_matrix, self.x)
-        temp = simulated_annealing.initial_temperature(
+        temp = simulated_annealing._initial_temperature(
             distance_matrix, self.x, fx, perturbation_scheme=scheme
         )
 
@@ -44,14 +46,14 @@ class TestSimulatedAnnealing:
     def test_acceptance_rule_improvement(self):
         """If fn < fx, the acceptance rule must return True"""
 
-        flag = simulated_annealing.acceptance_rule(2, 1, 1)
+        flag = simulated_annealing._acceptance_rule(2, 1, 1)
         assert flag
 
     @pytest.mark.parametrize(
         "distance_matrix",
         [distance_matrix1, distance_matrix2, distance_matrix3]
     )
-    @pytest.mark.parametrize("scheme", ["ps1", "ps2", "ps3"])
+    @pytest.mark.parametrize("scheme", perturbation_schemes)
     def test_simulated_annealing_solution(self, distance_matrix, scheme):
         """
         It is not possible to determine the returned solution, so this function

--- a/tests/test_simulated_annealing.py
+++ b/tests/test_simulated_annealing.py
@@ -6,7 +6,7 @@ from .data import (
     distance_matrix1, distance_matrix2, distance_matrix3,
 )
 
-perturbation_schemes = ["ps1", "ps2", "ps3"]
+perturbation_schemes = ["ps1", "ps2", "ps3", "ps4", "ps5", "ps6"]
 
 
 class TestSimulatedAnnealing:

--- a/tests/test_simulated_annealing.py
+++ b/tests/test_simulated_annealing.py
@@ -6,7 +6,7 @@ from .data import (
     distance_matrix1, distance_matrix2, distance_matrix3,
 )
 
-perturbation_schemes = ["ps1", "ps2", "ps3", "ps4", "ps5", "ps6"]
+perturbation_schemes = ["ps1", "ps2", "ps3", "ps4", "ps5", "ps6", "two_opt"]
 
 
 class TestSimulatedAnnealing:


### PR DESCRIPTION
This PR completes the PS types of perturbation schemes, adding all up to PS6 and the 2-opt.

The PS6 became the default since it has more neighbors and thus a better chance of finding improved solutions.

Minor changes:
- Regression of `jedi<0.18` because the autocomplete fails in `ipdb` debugging. This changes nothing in production;
- Local Search and Simulated Annealing now, by default, return a permutation starting at 0 (unless a different permutation is input).

This should become version `0.2.0` because of the addition of new features.