### PR TITLE
Version 0.1.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,3 +158,41 @@ coverage:
 .. code:: bash
 
   poetry run pytest --cov=. --cov-report=term-missing --cov-fail-under=95 tests/
+
+
+Release Notes and Changelog
+===========================
+
+Release 0.1.2
+-------------
+- Local search and Simulated Annealing random solution now begins at root node
+  0 just like the exact methods.
+
+Python support:
+
+* Python >= 3.6
+
+Release 0.1.1
+-------------
+
+Improved Python versions support.
+
+Python support:
+
+* Python >= 3.6
+
+
+Release 0.1.0
+-------------
+
+Initial version. Support for the following solvers:
+
+* Exact (Brute force and Dynamic Programming);
+* Heuristics (Local Search and Simulated Annealing).
+
+The local search-based algorithms can be run with neighborhoods PS1, PS2 and
+PS3.
+
+Python support:
+
+* Python >= 3.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "python_tsp"
-version = "0.1.1"
+version = "0.1.2"
 description = "Simple library to solve the Traveling Salesperson Problem in pure Python."
 readme = "README_pypi.rst"
 authors = ["Fillipe Goulart <fillipe.gsm@tutanota.com>"]

--- a/python_tsp/heuristics/local_search.py
+++ b/python_tsp/heuristics/local_search.py
@@ -1,6 +1,6 @@
 """Simple local search solver"""
+from random import sample
 from typing import List, Optional, Tuple
-import random
 
 import numpy as np
 
@@ -95,7 +95,7 @@ def setup(
 
     if not x0:
         n = distance_matrix.shape[0]  # number of nodes
-        x0 = random.sample(range(n), n)
+        x0 = [0] + sample(range(1, n), n - 1)  # ensure 0 is the first node
 
     fx0 = compute_permutation_distance(distance_matrix, x0)
     return x0, fx0

--- a/tests/test_local_search.py
+++ b/tests/test_local_search.py
@@ -49,13 +49,15 @@ class TestLocalSearch:
     )
     def test_setup_return_random_valid_solution(self, distance_matrix):
         """
-        The setup outputs a random valid permutation if no
-        initial solution is provided
+        The setup outputs a random valid permutation if no initial solution
+        is provided. This permutation must contain all nodes from 0 to n - 1
+        and start at 0 (the root).
         """
 
         x, fx = local_search.setup(distance_matrix)
 
         assert set(x) == set(range(distance_matrix.shape[0]))
+        assert x[0] == 0
         assert fx
 
     @pytest.mark.parametrize("scheme", ["ps1", "ps2", "ps3"])

--- a/tests/test_simulated_annealing.py
+++ b/tests/test_simulated_annealing.py
@@ -57,7 +57,7 @@ class TestSimulatedAnnealing:
     def test_simulated_annealing_solution(self, distance_matrix, scheme):
         """
         It is not possible to determine the returned solution, so this function
-        just checks if it is valid and has all nodes
+        just checks if it is valid: it has all nodes and begins at the root 0.
         """
 
         x, _ = simulated_annealing.solve_tsp_simulated_annealing(
@@ -65,3 +65,4 @@ class TestSimulatedAnnealing:
         )
 
         assert set(x) == set(range(5))
+        assert x[0] == 0


### PR DESCRIPTION
# Description
Fix bug where local search-based methods can have its permutation not starting at root 0.

This PR ensures the first node is `0`, and the other ones are properly randomized.

