### PR TITLE
Add support for OSRM distance matrix calculations

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -49,6 +49,25 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "certifi"
+version = "2022.5.18.1"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "charset-normalizer"
+version = "2.0.12"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.5.0"
+
+[package.extras]
+unicode_backport = ["unicodedata2"]
+
+[[package]]
 name = "click"
 version = "8.1.2"
 description = "Composable command line interface toolkit"
@@ -117,6 +136,14 @@ importlib-metadata = {version = "<4.3", markers = "python_version < \"3.8\""}
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.8.0,<2.9.0"
 pyflakes = ">=2.4.0,<2.5.0"
+
+[[package]]
+name = "idna"
+version = "3.3"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = ">=3.5"
 
 [[package]]
 name = "importlib-metadata"
@@ -220,6 +247,19 @@ description = "McCabe checker, plugin for flake8"
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "mock"
+version = "4.0.3"
+description = "Rolling backport of unittest.mock for all Pythons"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+build = ["twine", "wheel", "blurb"]
+docs = ["sphinx"]
+test = ["pytest (<5.4)", "pytest-cov"]
 
 [[package]]
 name = "mypy"
@@ -424,6 +464,24 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "requests"
+version = "2.28.0"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=3.7, <4"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = ">=2.0.0,<2.1.0"
+idna = ">=2.5,<4"
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+
+[[package]]
 name = "tabulate"
 version = "0.8.9"
 description = "Pretty-print tabular data"
@@ -492,6 +550,19 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "urllib3"
+version = "1.26.9"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
 name = "wcwidth"
 version = "0.2.5"
 description = "Measures the displayed width of unicode strings in a terminal"
@@ -522,7 +593,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "7725844b3519067c544a28fa3f172f34c245d92e463b50f592fd379aee94098c"
+content-hash = "51637dc9fce1f404594545d0dea41115099488c5b923996c95253f21d51180d0"
 
 [metadata.files]
 appnope = [
@@ -544,6 +615,14 @@ autopep8 = [
 backcall = [
     {file = "backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"},
     {file = "backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e"},
+]
+certifi = [
+    {file = "certifi-2022.5.18.1-py3-none-any.whl", hash = "sha256:f1d53542ee8cbedbe2118b5686372fb33c297fcd6379b050cca0ef13a597382a"},
+    {file = "certifi-2022.5.18.1.tar.gz", hash = "sha256:9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7"},
+]
+charset-normalizer = [
+    {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
+    {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
 ]
 click = [
     {file = "click-8.1.2-py3-none-any.whl", hash = "sha256:24e1a4a9ec5bf6299411369b208c1df2188d9eb8d916302fe6bf03faed227f1e"},
@@ -608,6 +687,10 @@ flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
     {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
 ]
+idna = [
+    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
+    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+]
 importlib-metadata = [
     {file = "importlib_metadata-4.2.0-py3-none-any.whl", hash = "sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b"},
     {file = "importlib_metadata-4.2.0.tar.gz", hash = "sha256:b7e52a1f8dec14a75ea73e0891f3060099ca1d8e6a462a4dff11c3e119ea1b31"},
@@ -634,6 +717,10 @@ matplotlib-inline = [
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+mock = [
+    {file = "mock-4.0.3-py3-none-any.whl", hash = "sha256:122fcb64ee37cfad5b3f48d7a7d51875d7031aaf3d8be7c42e2bee25044eee62"},
+    {file = "mock-4.0.3.tar.gz", hash = "sha256:7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc"},
 ]
 mypy = [
     {file = "mypy-0.782-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:2c6cde8aa3426c1682d35190b59b71f661237d74b053822ea3d748e2c9578a7c"},
@@ -745,6 +832,10 @@ pytest-cov = [
     {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
     {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
 ]
+requests = [
+    {file = "requests-2.28.0-py3-none-any.whl", hash = "sha256:bc7861137fbce630f17b03d3ad02ad0bf978c844f3536d0edda6499dafce2b6f"},
+    {file = "requests-2.28.0.tar.gz", hash = "sha256:d568723a7ebd25875d8d1eaf5dfa068cd2fc8194b2e483d7b1f7c81918dbec6b"},
+]
 tabulate = [
     {file = "tabulate-0.8.9-py3-none-any.whl", hash = "sha256:d7c013fe7abbc5e491394e10fa845f8f32fe54f8dc60c6622c6cf482d25d47e4"},
     {file = "tabulate-0.8.9.tar.gz", hash = "sha256:eb1d13f25760052e8931f2ef80aaf6045a6cceb47514db8beab24cded16f13a7"},
@@ -800,6 +891,10 @@ typed-ast = [
 typing-extensions = [
     {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
     {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
+    {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ license = "MIT"
 python = "^3.7.1"
 tsplib95 = "^0.7.1"
 numpy = "*"
+requests = "^2.28.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.1"
@@ -19,6 +20,7 @@ mypy = "^0.782"
 autopep8 = "^1.6.0"
 flake8 = "^4.0.1"
 pytest-cov = "^3.0.0"
+mock = "^4.0.3"
 
 [tool.autopep8]
 max_line_length = 79

--- a/python_tsp/distances/__init__.py
+++ b/python_tsp/distances/__init__.py
@@ -4,4 +4,5 @@
 """
 from .euclidean_distance import euclidean_distance_matrix  # noqa: F401
 from .great_circle_distance import great_circle_distance_matrix  # noqa: F401
+from .osrm_distance import osrm_distance_matrix  # noqa: F401
 from .tsplib_distance import tsplib_distance_matrix  # noqa: F401

--- a/python_tsp/distances/osrm_distance.py
+++ b/python_tsp/distances/osrm_distance.py
@@ -1,0 +1,156 @@
+from math import ceil
+
+import numpy as np
+import requests
+
+
+def osrm_distance_matrix(
+    sources: np.ndarray,
+    destinations: np.ndarray,
+    osrm_server_address: str = "http://localhost:5000",
+    osrm_batch_size: int = 500,
+    cost_type: str = "distances",
+) -> np.ndarray:
+    """Compute distance matrix from sources to destinations using OSRM service
+
+    Parameters
+    ----------
+    sources, destinations
+        2D Arrays of coordinates in the form [lat, lng] for each row
+
+    osrm_server_address
+        Base address of the OSRM server instance
+
+    osrm_batch_size
+        Subset of sources and destinations for each request. This reduces the
+        request size, thus alleviating max table issues, but slows down the
+        search
+
+    cost_type
+        "distances" to get the street distances and "durations" for the street
+        time
+
+    Returns
+    -------
+    Distance (or duration) matrix of size `num_sources x num_destinations`
+    """
+    num_sources = sources.shape[0]
+    num_destinations = destinations.shape[0]
+    cost_matrix = np.zeros((num_sources, num_destinations))
+
+    num_batches_i = ceil(num_sources / osrm_batch_size)
+    num_batches_j = ceil(num_destinations / osrm_batch_size)
+
+    for i in range(num_batches_i):
+        start_i = i * osrm_batch_size
+        end_i = min((i + 1) * osrm_batch_size, num_sources)
+
+        for j in range(num_batches_j):
+            start_j = j * osrm_batch_size
+            end_j = min((j + 1) * osrm_batch_size, num_destinations)
+            sources_batch = sources[start_i:end_i]
+            destinations_batch = destinations[start_j:end_j]
+
+            cost_matrix[
+                start_i:end_i, start_j:end_j
+            ] = _get_batch_osrm_distance(
+                sources_batch,
+                destinations_batch,
+                osrm_server_address,
+                cost_type=cost_type,
+            )
+
+    return cost_matrix
+
+
+def _get_batch_osrm_distance(
+    sources_batch: np.ndarray,
+    destinations_batch: np.ndarray,
+    osrm_server_address: str,
+    cost_type: str,
+):
+    """Request the OSRM distance matrix for a given batch"""
+    url = _format_osrm_url(
+        sources_batch, destinations_batch, osrm_server_address, cost_type
+    )
+    resp = requests.get(url)
+    resp.raise_for_status()
+
+    return np.array(resp.json()[cost_type])
+
+
+def _format_osrm_url(
+    sources_batch: np.ndarray,
+    destinations_batch: np.ndarray,
+    osrm_server_address: str,
+    cost_type: str,
+) -> str:
+    """Format OSRM url string with sources and destinations
+
+    Notes
+    -----
+    Consider the N sources in the form
+        (lat_src1, lgn_src1), (lat_src2, lgn_src2), ...
+
+    and the M destinations in the form
+        (lat_dest1, lgn_dest1), (lat_dest2, lgn_dest2), ...
+
+    This function converts these properties in a URL of the form
+        {OSRM_SERVER_ADDRESS}/table/v1/driving/
+        lng_src1,lat_src1;lng_src2,lat_src2;...;lng_srcN,lat_srcN;
+        lng_dest1,lat_dest1;lng_dest2,lat_dest2;...;lng_destM,lng_destM
+        ?sources=0;1;...;N-1
+        &destinations=N;N+1;...;N+M-1
+        &annotations=distance
+
+    In the simpler case when sources == destinations, the URL is simplified to
+        {OSRM_SERVER_ADDRESS}/table/v1/driving/
+        lng_src1,lat_src1;lng_src2,lat_src2;...;lng_srcN,lat_srcN
+        ?annotations=distance
+
+    Obs: Replace "distance" with "duration" if a time matrix is required
+    Obs2: The matrix type follows the singular form in the URL (e.g.,
+    "distance"), but the returned JSON follows the plural form (e.g.,
+    "distances"). Thus, we ignore the last letter of the input type
+    """
+    url_cost_type = cost_type[:-1]
+
+    sources_coord = ";".join(
+        f"{source[1]},{source[0]}" for source in sources_batch
+    )
+
+    # If sources == destinations, return a simpler URL early. Notice it needs
+    # at least two points, otherwise OSRM complains
+    if (
+        np.array_equal(sources_batch, destinations_batch)
+        and sources_batch.shape[0] > 1
+    ):
+        return (
+            f"{osrm_server_address}/table/v1/driving/"
+            f"{sources_coord}"
+            f"?annotations={url_cost_type}"
+        )
+
+    destinations_coord = ";".join(
+        f"{destination[1]},{destination[0]}"
+        for destination in destinations_batch
+    )
+    locations_coord = sources_coord + ";" + destinations_coord
+
+    # Get indices of sources and destinations in the form
+    # sources = 0,1,...,N' and destinations = N'+1,N'+2...N'+M'
+    num_sources = sources_batch.shape[0]
+    num_destinations = destinations_batch.shape[0]
+
+    sources_indices = ";".join(str(index) for index in range(num_sources))
+    destinations_indices = ";".join(
+        str(index)
+        for index in range(num_sources, num_sources + num_destinations)
+    )
+
+    return (
+        f"{osrm_server_address}/table/v1/driving/"
+        f"{locations_coord}"
+        f"?sources={sources_indices}&destinations={destinations_indices}"
+        f"&annotations={url_cost_type}"
+    )

--- a/tests/distances/test_osrm_distance.py
+++ b/tests/distances/test_osrm_distance.py
@@ -1,0 +1,117 @@
+import numpy as np
+import pytest
+from mock import patch
+from requests import Response
+from requests.exceptions import HTTPError
+
+from python_tsp.distances import osrm_distance_matrix
+
+
+@pytest.fixture
+def mocked_osrm_valid_call():
+    with patch("python_tsp.distances.osrm_distance.requests.get") as (
+        mocked_get
+    ):
+        mocked_return_value = Response()
+        mocked_return_value.status_code = 200
+        mocked_return_value.json = lambda: {
+            "code": "Ok",
+            "distances": np.array([[0, 50], [50, 0]]),
+            "durations": np.array([[0, 5], [5, 0]]),
+        }
+        mocked_get.return_value = mocked_return_value
+
+        yield mocked_get
+
+
+@pytest.fixture
+def mocked_osrm_invalid_call():
+    """It happens when no service is working or the input is invalid"""
+    with patch("python_tsp.distances.osrm_distance.requests.get") as (
+        mocked_get
+    ):
+        mocked_return_value = Response()
+        mocked_return_value.status_code = 400
+        mocked_get.return_value = mocked_return_value
+
+        yield mocked_get
+
+
+@pytest.mark.usefixtures("mocked_osrm_valid_call")
+def test_osrm_distance_valid_call():
+    sources = np.array([[0.0, 0.0], [1.0, 1.0]])
+
+    cost_matrix = osrm_distance_matrix(sources, sources)
+
+    num_sources = sources.shape[0]
+    assert cost_matrix.shape == (num_sources, num_sources)
+
+
+@pytest.mark.usefixtures("mocked_osrm_invalid_call")
+def test_osrm_distance_invalid_call():
+    sources = np.array([[0.0, 0.0], [1.0, 1.0]])
+
+    with pytest.raises(HTTPError):
+        osrm_distance_matrix(sources, sources)
+
+
+def test_osrm_distance_call_square_matrix(mocked_osrm_valid_call):
+    sources = np.array([[0.0, 0.0], [1.0, 1.0]])
+    osrm_server_address = "BASE_URL"
+
+    osrm_distance_matrix(
+        sources,
+        sources,
+        osrm_server_address=osrm_server_address,
+        cost_type="distances",
+    )
+
+    expected_url_call = (
+        f"{osrm_server_address}/table/v1/driving/"
+        f"0.0,0.0;1.0,1.0"
+        "?annotations=distance"
+    )
+
+    mocked_osrm_valid_call.assert_called_with(expected_url_call)
+
+
+def test_osrm_distance_call_nonsquare_matrix(mocked_osrm_valid_call):
+    sources = np.array([[0.0, 0.0], [1.0, 1.0]])
+    destinations = np.array([[2.0, 2.0], [3.0, 3.0]])
+    osrm_server_address = "BASE_URL"
+
+    osrm_distance_matrix(
+        sources,
+        destinations,
+        osrm_server_address=osrm_server_address,
+        cost_type="distances",
+    )
+
+    expected_url_call = (
+        f"{osrm_server_address}/table/v1/driving/"
+        f"0.0,0.0;1.0,1.0;2.0,2.0;3.0,3.0"
+        "?sources=0;1&destinations=2;3&annotations=distance"
+    )
+
+    mocked_osrm_valid_call.assert_called_with(expected_url_call)
+
+
+def test_osrm_distance_call_durations_cost(mocked_osrm_valid_call):
+    """Check if the URL is changed when the cost type is different"""
+    sources = np.array([[0.0, 0.0], [1.0, 1.0]])
+    osrm_server_address = "BASE_URL"
+
+    osrm_distance_matrix(
+        sources,
+        sources,
+        osrm_server_address=osrm_server_address,
+        cost_type="durations",
+    )
+
+    expected_url_call = (
+        f"{osrm_server_address}/table/v1/driving/"
+        f"0.0,0.0;1.0,1.0"
+        "?annotations=duration"
+    )
+
+    mocked_osrm_valid_call.assert_called_with(expected_url_call)


### PR DESCRIPTION
It should now be possible to compute street distances (and durations) via the Open Source Routing Machine service.