### PR TITLE
Replace logger with print

### DIFF
--- a/python_tsp/heuristics/local_search.py
+++ b/python_tsp/heuristics/local_search.py
@@ -75,7 +75,8 @@ def solve_tsp_local_search(
                 warning_msg = "WARNING: Stopping early due to time constraints"
                 if log_file:
                     print(warning_msg, file=log_file_handler)
-                print(warning_msg)
+                if verbose:
+                    print(warning_msg)
                 stop_early = True
                 break
 

--- a/python_tsp/heuristics/local_search.py
+++ b/python_tsp/heuristics/local_search.py
@@ -1,5 +1,4 @@
 """Simple local search solver"""
-import logging
 from random import sample
 from timeit import default_timer
 from typing import List, Optional, Tuple
@@ -10,18 +9,11 @@ from python_tsp.utils import compute_permutation_distance
 from python_tsp.heuristics.perturbation_schemes import neighborhood_gen
 
 
-logger = logging.getLogger(__name__)
-ch = logging.StreamHandler()
-ch.setLevel(level=logging.WARNING)
-logger.addHandler(ch)
-
-
 def solve_tsp_local_search(
     distance_matrix: np.ndarray,
     x0: Optional[List[int]] = None,
     perturbation_scheme: str = "two_opt",
-    max_processing_time: Optional[float] = None,
-    log_file: Optional[str] = None,
+    max_processing_time: Optional[float] = None
 ) -> Tuple[List, float]:
     """Solve a TSP problem with a local search heuristic
 
@@ -40,10 +32,6 @@ def solve_tsp_local_search(
     max_processing_time {None}
         Maximum processing time in seconds. If not provided, the method stops
         only when a local minimum is obtained
-
-    log_file
-        If not `None`, creates a log file with details about the whole
-        execution
 
     Returns
     -------
@@ -65,11 +53,6 @@ def solve_tsp_local_search(
     """
     x, fx = setup(distance_matrix, x0)
     max_processing_time = max_processing_time or np.inf
-    if log_file:
-        fh = logging.FileHandler(log_file)
-        fh.setLevel(logging.INFO)
-        logger.addHandler(fh)
-        logger.setLevel(logging.INFO)
 
     tic = default_timer()
     stop_early = False
@@ -78,12 +61,12 @@ def solve_tsp_local_search(
         improvement = False
         for n_index, xn in enumerate(neighborhood_gen[perturbation_scheme](x)):
             if default_timer() - tic > max_processing_time:
-                logger.warning("Stopping early due to time constraints")
+                print("WARNING: Stopping early due to time constraints")
                 stop_early = True
                 break
 
             fn = compute_permutation_distance(distance_matrix, xn)
-            logger.info(f"Current value: {fx}; Neighbor: {n_index}")
+            print(f"Current value: {fx}; Neighbor: {n_index}")
 
             if fn < fx:
                 improvement = True

--- a/python_tsp/heuristics/local_search.py
+++ b/python_tsp/heuristics/local_search.py
@@ -1,5 +1,4 @@
 """Simple local search solver"""
-import logging
 from random import sample
 from timeit import default_timer
 from typing import List, Optional, Tuple
@@ -8,12 +7,6 @@ import numpy as np
 
 from python_tsp.utils import compute_permutation_distance
 from python_tsp.heuristics.perturbation_schemes import neighborhood_gen
-
-
-logger = logging.getLogger(__name__)
-ch = logging.StreamHandler()
-ch.setLevel(level=logging.WARNING)
-logger.addHandler(ch)
 
 
 def solve_tsp_local_search(
@@ -70,10 +63,7 @@ def solve_tsp_local_search(
     x, fx = setup(distance_matrix, x0)
     max_processing_time = max_processing_time or np.inf
     if log_file:
-        fh = logging.FileHandler(log_file)
-        fh.setLevel(logging.INFO)
-        logger.addHandler(fh)
-        logger.setLevel(logging.INFO)
+        log_file_handler = open(log_file, "w", encoding="utf-8")
 
     tic = default_timer()
     stop_early = False
@@ -82,10 +72,10 @@ def solve_tsp_local_search(
         improvement = False
         for n_index, xn in enumerate(neighborhood_gen[perturbation_scheme](x)):
             if default_timer() - tic > max_processing_time:
-                warning_msg = "Stopping early due to time constraints"
+                warning_msg = "WARNING: Stopping early due to time constraints"
                 if log_file:
-                    logger.warning(warning_msg)
-                print(f"WARNING: {warning_msg}")
+                    print(warning_msg, file=log_file_handler)
+                print(warning_msg)
                 stop_early = True
                 break
 
@@ -93,7 +83,7 @@ def solve_tsp_local_search(
 
             msg = f"Current value: {fx}; Neighbor: {n_index}"
             if log_file:
-                logger.info(msg)
+                print(msg, file=log_file_handler)
             if verbose:
                 print(msg)
 

--- a/python_tsp/heuristics/local_search.py
+++ b/python_tsp/heuristics/local_search.py
@@ -22,6 +22,7 @@ def solve_tsp_local_search(
     perturbation_scheme: str = "two_opt",
     max_processing_time: Optional[float] = None,
     log_file: Optional[str] = None,
+    verbose: bool = False,
 ) -> Tuple[List, float]:
     """Solve a TSP problem with a local search heuristic
 
@@ -44,6 +45,9 @@ def solve_tsp_local_search(
     log_file
         If not `None`, creates a log file with details about the whole
         execution
+
+    verbose
+        If true, prints algorithm status every iteration
 
     Returns
     -------
@@ -90,7 +94,8 @@ def solve_tsp_local_search(
             msg = f"Current value: {fx}; Neighbor: {n_index}"
             if log_file:
                 logger.info(msg)
-            print(msg)
+            if verbose:
+                print(msg)
 
             if fn < fx:
                 improvement = True

--- a/python_tsp/heuristics/simulated_annealing.py
+++ b/python_tsp/heuristics/simulated_annealing.py
@@ -1,4 +1,3 @@
-import logging
 from timeit import default_timer
 from typing import List, Optional, Tuple
 
@@ -7,12 +6,6 @@ import numpy as np
 from python_tsp.heuristics.perturbation_schemes import neighborhood_gen
 from python_tsp.heuristics.local_search import setup
 from python_tsp.utils import compute_permutation_distance
-
-
-logger = logging.getLogger(__name__)
-ch = logging.StreamHandler()
-ch.setLevel(level=logging.WARNING)
-logger.addHandler(ch)
 
 
 def solve_tsp_simulated_annealing(
@@ -74,10 +67,7 @@ def solve_tsp_simulated_annealing(
     temp = _initial_temperature(distance_matrix, x, fx, perturbation_scheme)
     max_processing_time = max_processing_time or np.inf
     if log_file:
-        fh = logging.FileHandler(log_file)
-        fh.setLevel(logging.INFO)
-        logger.addHandler(fh)
-        logger.setLevel(logging.INFO)
+        log_file_handler = open(log_file, "w", encoding="utf-8")
 
     n = len(x)
     k_inner_min = n  # min inner iterations
@@ -90,10 +80,10 @@ def solve_tsp_simulated_annealing(
         k_accepted = 0  # number of accepted perturbations
         for k in range(k_inner_max):
             if default_timer() - tic > max_processing_time:
-                warning_msg = "Stopping early due to time constraints"
+                warning_msg = "WARNING: Stopping early due to time constraints"
                 if log_file:
-                    logger.warning(warning_msg)
-                print(f"WARNING: {warning_msg}")
+                    print(warning_msg, file=log_file_handler)
+                print(warning_msg)
                 stop_early = True
                 break
 
@@ -112,7 +102,7 @@ def solve_tsp_simulated_annealing(
                 f"k_noimprovements: {k_noimprovements}"
             )
             if log_file:
-                logger.info(msg)
+                print(msg, file=log_file_handler)
             if verbose:
                 print(msg)
 

--- a/python_tsp/heuristics/simulated_annealing.py
+++ b/python_tsp/heuristics/simulated_annealing.py
@@ -22,6 +22,7 @@ def solve_tsp_simulated_annealing(
     alpha: float = 0.9,
     max_processing_time: float = None,
     log_file: Optional[str] = None,
+    verbose: bool = False
 ) -> Tuple[List, float]:
     """Solve a TSP problem using a Simulated Annealing
     The approach used here is the one proposed in [1].
@@ -52,6 +53,9 @@ def solve_tsp_simulated_annealing(
     log_file
         If not `None`, creates a log file with details about the whole
         execution
+
+    verbose
+        If true, prints algorithm status every iteration
 
     Returns
     -------
@@ -109,7 +113,8 @@ def solve_tsp_simulated_annealing(
             )
             if log_file:
                 logger.info(msg)
-            print(msg)
+            if verbose:
+                print(msg)
 
             if k_accepted >= k_inner_min:
                 break

--- a/python_tsp/heuristics/simulated_annealing.py
+++ b/python_tsp/heuristics/simulated_annealing.py
@@ -83,7 +83,8 @@ def solve_tsp_simulated_annealing(
                 warning_msg = "WARNING: Stopping early due to time constraints"
                 if log_file:
                     print(warning_msg, file=log_file_handler)
-                print(warning_msg)
+                if verbose:
+                    print(warning_msg)
                 stop_early = True
                 break
 

--- a/python_tsp/heuristics/simulated_annealing.py
+++ b/python_tsp/heuristics/simulated_annealing.py
@@ -1,4 +1,3 @@
-import logging
 from timeit import default_timer
 from typing import List, Optional, Tuple
 
@@ -9,19 +8,12 @@ from python_tsp.heuristics.local_search import setup
 from python_tsp.utils import compute_permutation_distance
 
 
-logger = logging.getLogger(__name__)
-ch = logging.StreamHandler()
-ch.setLevel(level=logging.WARNING)
-logger.addHandler(ch)
-
-
 def solve_tsp_simulated_annealing(
     distance_matrix: np.ndarray,
     x0: Optional[List[int]] = None,
     perturbation_scheme: str = "two_opt",
     alpha: float = 0.9,
     max_processing_time: float = None,
-    log_file: Optional[str] = None,
 ) -> Tuple[List, float]:
     """Solve a TSP problem using a Simulated Annealing
     The approach used here is the one proposed in [1].
@@ -49,10 +41,6 @@ def solve_tsp_simulated_annealing(
         Maximum processing time in seconds. If not provided, the method stops
         only when there were 3 temperature cycles with no improvement.
 
-    log_file
-        If not `None`, creates a log file with details about the whole
-        execution
-
     Returns
     -------
     A permutation of nodes from 0 to n - 1 that produces the least total
@@ -69,11 +57,6 @@ def solve_tsp_simulated_annealing(
     x, fx = setup(distance_matrix, x0)
     temp = _initial_temperature(distance_matrix, x, fx, perturbation_scheme)
     max_processing_time = max_processing_time or np.inf
-    if log_file:
-        fh = logging.FileHandler(log_file)
-        fh.setLevel(logging.INFO)
-        logger.addHandler(fh)
-        logger.setLevel(logging.INFO)
 
     n = len(x)
     k_inner_min = n  # min inner iterations
@@ -86,7 +69,7 @@ def solve_tsp_simulated_annealing(
         k_accepted = 0  # number of accepted perturbations
         for k in range(k_inner_max):
             if default_timer() - tic > max_processing_time:
-                logger.warning("Stopping early due to time constraints")
+                print("WARNING: Stopping early due to time constraints")
                 stop_early = True
                 break
 
@@ -98,7 +81,7 @@ def solve_tsp_simulated_annealing(
                 k_accepted += 1
                 k_noimprovements = 0
 
-            logger.info(
+            print(
                 f"Temperature {temp}. Current value: {fx} "
                 f"k: {k + 1}/{k_inner_max} "
                 f"k_accepted: {k_accepted}/{k_inner_min} "

--- a/tests/test_local_search.py
+++ b/tests/test_local_search.py
@@ -135,6 +135,7 @@ class TestLocalSearch:
             distance_matrix,
             perturbation_scheme=scheme,
             max_processing_time=max_processing_time,
+            verbose=True
         )
 
         assert "WARNING: Stopping early due to time constraints" in \

--- a/tests/test_local_search.py
+++ b/tests/test_local_search.py
@@ -120,7 +120,7 @@ class TestLocalSearch:
         it seems to vary a bit between platforms. For instance, locally it may
         take a few milisseconds more, but on Github it may be a few whole
         seconds.
-        Thus, this test checks if a proper warning log is created if the time
+        Thus, this test checks if a proper warning is printed if the time
         constraint stopped execution early.
         """
 
@@ -139,3 +139,17 @@ class TestLocalSearch:
 
         assert "WARNING: Stopping early due to time constraints" in \
                captured_output.getvalue()
+
+    def test_log_file_is_created_if_required(self, tmp_path):
+        """
+        If a log_file is provided, it contains information about the execution.
+        """
+
+        log_file = tmp_path / "tmp_log_file.log"
+
+        local_search.solve_tsp_local_search(
+            distance_matrix1, log_file=log_file
+        )
+
+        assert log_file.exists()
+        assert "Current value" in log_file.read_text()

--- a/tests/test_local_search.py
+++ b/tests/test_local_search.py
@@ -1,7 +1,8 @@
+import sys
+from io import StringIO
+
 import numpy as np
 import pytest
-from io import StringIO
-import sys
 
 from python_tsp.heuristics import local_search
 from python_tsp.utils import compute_permutation_distance

--- a/tests/test_simulated_annealing.py
+++ b/tests/test_simulated_annealing.py
@@ -78,7 +78,7 @@ class TestSimulatedAnnealing:
         respect the provided limits, but it seems to vary a bit between
         platforms. For instance, locally it may take a few milisseconds more,
         but on Github it may be a few whole seconds.
-        Thus, this test checks if a proper warning log is created if the time
+        Thus, this test checks if a proper warning is printed if the time
         constraint stopped execution early.
         """
 
@@ -97,3 +97,18 @@ class TestSimulatedAnnealing:
 
         assert "WARNING: Stopping early due to time constraints" in \
                captured_output.getvalue()
+
+    def test_log_file_is_created_if_required(self, tmp_path):
+        """
+        If a log_file is provided, it contains information about the execution.
+        """
+
+        log_file = tmp_path / "tmp_log_file.log"
+
+        simulated_annealing.solve_tsp_simulated_annealing(
+            distance_matrix1, log_file=log_file
+        )
+
+        assert log_file.exists()
+        assert "Temperature" in log_file.read_text()
+        assert "Current value" in log_file.read_text()

--- a/tests/test_simulated_annealing.py
+++ b/tests/test_simulated_annealing.py
@@ -1,5 +1,7 @@
 import numpy as np
 import pytest
+from io import StringIO
+import sys
 
 from python_tsp.heuristics import simulated_annealing
 from python_tsp.utils import compute_permutation_distance
@@ -69,7 +71,7 @@ class TestSimulatedAnnealing:
         assert x[0] == 0
 
     @pytest.mark.parametrize("scheme", perturbation_schemes)
-    def test_simulated_annealing_with_time_constraints(self, scheme, caplog):
+    def test_simulated_annealing_with_time_constraints(self, scheme):
         """
         Just like in the local search test, the actual time execution tends to
         respect the provided limits, but it seems to vary a bit between
@@ -83,25 +85,14 @@ class TestSimulatedAnnealing:
         np.random.seed(1)  # for repeatability with the same distance matrix
         distance_matrix = np.random.rand(5000, 5000)  # very large matrix
 
+        captured_output = StringIO()  # Create StringIO object
+        sys.stdout = captured_output  # and redirect stdout.
+
         simulated_annealing.solve_tsp_simulated_annealing(
             distance_matrix,
             perturbation_scheme=scheme,
             max_processing_time=max_processing_time,
         )
 
-        assert "Stopping early due to time constraints" in caplog.text
-
-    def test_log_file_is_created_if_required(self, tmp_path):
-        """
-        If a log_file is provided, it contains information about the execution.
-        """
-
-        log_file = tmp_path / "tmp_log_file.log"
-
-        simulated_annealing.solve_tsp_simulated_annealing(
-            distance_matrix1, log_file=log_file
-        )
-
-        assert log_file.exists()
-        assert "Temperature" in log_file.read_text()
-        assert "Current value" in log_file.read_text()
+        assert "WARNING: Stopping early due to time constraints" in \
+               captured_output.getvalue()

--- a/tests/test_simulated_annealing.py
+++ b/tests/test_simulated_annealing.py
@@ -1,7 +1,8 @@
+import sys
+from io import StringIO
+
 import numpy as np
 import pytest
-from io import StringIO
-import sys
 
 from python_tsp.heuristics import simulated_annealing
 from python_tsp.utils import compute_permutation_distance

--- a/tests/test_simulated_annealing.py
+++ b/tests/test_simulated_annealing.py
@@ -93,6 +93,7 @@ class TestSimulatedAnnealing:
             distance_matrix,
             perturbation_scheme=scheme,
             max_processing_time=max_processing_time,
+            verbose=True
         )
 
         assert "WARNING: Stopping early due to time constraints" in \


### PR DESCRIPTION
See #19 

In short, this 
 - replaces `logger.info()` with `print()` and `logger.warning()` with `print("WARNING: ")`
 - keeps `logger.info()`/`logger.warning()` only for `log_file` writing