### PR TITLE
Replace `autopep8` with `black` formatter

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,12 +32,12 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --ignore=E203,W503
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Check autopep8 was run
+    - name: Check black formatter was run
       run: |
-        poetry run autopep8 --recursive --aggressive --diff .
+        poetry run black .
     - name: Check type hints with mypy
       run: |
         poetry run mypy --ignore-missing-imports .

--- a/.scripts/checkup_scripts.sh
+++ b/.scripts/checkup_scripts.sh
@@ -2,7 +2,7 @@
 poetry run autopep8 --recursive --aggressive --in-place .
 
 # Check other requirements of PEP8
-poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --ignore=E203,W503
 # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
 poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=79 --statistics
 

--- a/.scripts/checkup_scripts.sh
+++ b/.scripts/checkup_scripts.sh
@@ -1,5 +1,5 @@
 # Run autopep8 to fix code
-poetry run autopep8 --recursive --aggressive --in-place .
+poetry run black .
 
 # Check other requirements of PEP8
 poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --ignore=E203,W503

--- a/poetry.lock
+++ b/poetry.lock
@@ -35,18 +35,6 @@ tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900
 tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
-name = "autopep8"
-version = "1.6.0"
-description = "A tool that automatically formats Python code to conform to the PEP 8 style guide"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-pycodestyle = ">=2.8.0"
-toml = "*"
-
-[[package]]
 name = "backcall"
 version = "0.2.0"
 description = "Specifications for callback functions passed in to an API"
@@ -700,7 +688,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8.1"
-content-hash = "6becc20ed589b4e90492c42aa90677ecd8baae9316184874992e297ede8d0c55"
+content-hash = "6f00ec5cce85dc3393896d9acc8c3e4e1edc984e332aaab90a4842fe569cb6c8"
 
 [metadata.files]
 appnope = [
@@ -714,10 +702,6 @@ asttokens = [
 attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
     {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
-]
-autopep8 = [
-    {file = "autopep8-1.6.0-py2.py3-none-any.whl", hash = "sha256:ed77137193bbac52d029a52c59bec1b0629b5a186c495f1eb21b126ac466083f"},
-    {file = "autopep8-1.6.0.tar.gz", hash = "sha256:44f0932855039d2c15c4510d6df665e4730f2b8582704fa48f9c55bd3e17d979"},
 ]
 backcall = [
     {file = "backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -55,6 +55,28 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "black"
+version = "22.10.0"
+description = "The uncompromising code formatter."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
+typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
 name = "certifi"
 version = "2022.9.24"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -152,16 +174,16 @@ tests = ["asttokens", "littleutils", "pytest", "rich"]
 
 [[package]]
 name = "flake8"
-version = "4.0.1"
+version = "6.0.0"
 description = "the modular source code checker: pep8 pyflakes and co"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8.1"
 
 [package.dependencies]
-mccabe = ">=0.6.0,<0.7.0"
-pycodestyle = ">=2.8.0,<2.9.0"
-pyflakes = ">=2.4.0,<2.5.0"
+mccabe = ">=0.7.0,<0.8.0"
+pycodestyle = ">=2.10.0,<2.11.0"
+pyflakes = ">=3.0.0,<3.1.0"
 
 [[package]]
 name = "idna"
@@ -257,11 +279,11 @@ traitlets = "*"
 
 [[package]]
 name = "mccabe"
-version = "0.6.1"
+version = "0.7.0"
 description = "McCabe checker, plugin for flake8"
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "mock"
@@ -350,6 +372,14 @@ qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
 testing = ["docopt", "pytest (<6.0.0)"]
 
 [[package]]
+name = "pathspec"
+version = "0.10.2"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "pexpect"
 version = "4.8.0"
 description = "Pexpect allows easy control of interactive console applications."
@@ -367,6 +397,18 @@ description = "Tiny 'shelve'-like database with concurrency support"
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "platformdirs"
+version = "2.5.4"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo (>=2022.9.29)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.4)"]
+test = ["appdirs (==1.4.4)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
 name = "pluggy"
@@ -412,19 +454,19 @@ tests = ["pytest"]
 
 [[package]]
 name = "pycodestyle"
-version = "2.8.0"
+version = "2.10.0"
 description = "Python style guide checker"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "pyflakes"
-version = "2.4.0"
+version = "3.0.1"
 description = "passive checker of Python programs"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "pygments"
@@ -658,7 +700,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8.1"
-content-hash = "999f59cbcf973b2c76fb55df870aceaba486f4becc91ee9beef48d7d5f5be460"
+content-hash = "6becc20ed589b4e90492c42aa90677ecd8baae9316184874992e297ede8d0c55"
 
 [metadata.files]
 appnope = [
@@ -680,6 +722,29 @@ autopep8 = [
 backcall = [
     {file = "backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"},
     {file = "backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e"},
+]
+black = [
+    {file = "black-22.10.0-1fixedarch-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:5cc42ca67989e9c3cf859e84c2bf014f6633db63d1cbdf8fdb666dcd9e77e3fa"},
+    {file = "black-22.10.0-1fixedarch-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:5d8f74030e67087b219b032aa33a919fae8806d49c867846bfacde57f43972ef"},
+    {file = "black-22.10.0-1fixedarch-cp37-cp37m-macosx_10_16_x86_64.whl", hash = "sha256:197df8509263b0b8614e1df1756b1dd41be6738eed2ba9e9769f3880c2b9d7b6"},
+    {file = "black-22.10.0-1fixedarch-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:2644b5d63633702bc2c5f3754b1b475378fbbfb481f62319388235d0cd104c2d"},
+    {file = "black-22.10.0-1fixedarch-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:e41a86c6c650bcecc6633ee3180d80a025db041a8e2398dcc059b3afa8382cd4"},
+    {file = "black-22.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2039230db3c6c639bd84efe3292ec7b06e9214a2992cd9beb293d639c6402edb"},
+    {file = "black-22.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14ff67aec0a47c424bc99b71005202045dc09270da44a27848d534600ac64fc7"},
+    {file = "black-22.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:819dc789f4498ecc91438a7de64427c73b45035e2e3680c92e18795a839ebb66"},
+    {file = "black-22.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5b9b29da4f564ba8787c119f37d174f2b69cdfdf9015b7d8c5c16121ddc054ae"},
+    {file = "black-22.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8b49776299fece66bffaafe357d929ca9451450f5466e997a7285ab0fe28e3b"},
+    {file = "black-22.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:21199526696b8f09c3997e2b4db8d0b108d801a348414264d2eb8eb2532e540d"},
+    {file = "black-22.10.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e464456d24e23d11fced2bc8c47ef66d471f845c7b7a42f3bd77bf3d1789650"},
+    {file = "black-22.10.0-cp37-cp37m-win_amd64.whl", hash = "sha256:9311e99228ae10023300ecac05be5a296f60d2fd10fff31cf5c1fa4ca4b1988d"},
+    {file = "black-22.10.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:fba8a281e570adafb79f7755ac8721b6cf1bbf691186a287e990c7929c7692ff"},
+    {file = "black-22.10.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:915ace4ff03fdfff953962fa672d44be269deb2eaf88499a0f8805221bc68c87"},
+    {file = "black-22.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:444ebfb4e441254e87bad00c661fe32df9969b2bf224373a448d8aca2132b395"},
+    {file = "black-22.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:974308c58d057a651d182208a484ce80a26dac0caef2895836a92dd6ebd725e0"},
+    {file = "black-22.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72ef3925f30e12a184889aac03d77d031056860ccae8a1e519f6cbb742736383"},
+    {file = "black-22.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:432247333090c8c5366e69627ccb363bc58514ae3e63f7fc75c54b1ea80fa7de"},
+    {file = "black-22.10.0-py3-none-any.whl", hash = "sha256:c957b2b4ea88587b46cf49d1dc17681c1e672864fd7af32fc1e9664d572b3458"},
+    {file = "black-22.10.0.tar.gz", hash = "sha256:f513588da599943e0cde4e32cc9879e825d58720d6557062d1098c5ad80080e1"},
 ]
 certifi = [
     {file = "certifi-2022.9.24-py3-none-any.whl", hash = "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"},
@@ -766,8 +831,8 @@ executing = [
     {file = "executing-1.2.0.tar.gz", hash = "sha256:19da64c18d2d851112f09c287f8d3dbbdf725ab0e569077efb6cdcbd3497c107"},
 ]
 flake8 = [
-    {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
-    {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
+    {file = "flake8-6.0.0-py2.py3-none-any.whl", hash = "sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7"},
+    {file = "flake8-6.0.0.tar.gz", hash = "sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181"},
 ]
 idna = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
@@ -793,8 +858,8 @@ matplotlib-inline = [
     {file = "matplotlib_inline-0.1.6-py3-none-any.whl", hash = "sha256:f1f41aab5328aa5aaea9b16d083b128102f8712542f819fe7e6a420ff581b311"},
 ]
 mccabe = [
-    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
-    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
+    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
 ]
 mock = [
     {file = "mock-4.0.3-py3-none-any.whl", hash = "sha256:122fcb64ee37cfad5b3f48d7a7d51875d7031aaf3d8be7c42e2bee25044eee62"},
@@ -878,6 +943,10 @@ parso = [
     {file = "parso-0.8.3-py2.py3-none-any.whl", hash = "sha256:c001d4636cd3aecdaf33cbb40aebb59b094be2a74c556778ef5576c175e19e75"},
     {file = "parso-0.8.3.tar.gz", hash = "sha256:8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0"},
 ]
+pathspec = [
+    {file = "pathspec-0.10.2-py3-none-any.whl", hash = "sha256:88c2606f2c1e818b978540f73ecc908e13999c6c3a383daf3705652ae79807a5"},
+    {file = "pathspec-0.10.2.tar.gz", hash = "sha256:8f6bf73e5758fd365ef5d58ce09ac7c27d2833a8d7da51712eac6e27e35141b0"},
+]
 pexpect = [
     {file = "pexpect-4.8.0-py2.py3-none-any.whl", hash = "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937"},
     {file = "pexpect-4.8.0.tar.gz", hash = "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"},
@@ -885,6 +954,10 @@ pexpect = [
 pickleshare = [
     {file = "pickleshare-0.7.5-py2.py3-none-any.whl", hash = "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"},
     {file = "pickleshare-0.7.5.tar.gz", hash = "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca"},
+]
+platformdirs = [
+    {file = "platformdirs-2.5.4-py3-none-any.whl", hash = "sha256:af0276409f9a02373d540bf8480021a048711d572745aef4b7842dad245eba10"},
+    {file = "platformdirs-2.5.4.tar.gz", hash = "sha256:1006647646d80f16130f052404c6b901e80ee4ed6bef6792e1f238a8969106f7"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
@@ -903,12 +976,12 @@ pure-eval = [
     {file = "pure_eval-0.2.2.tar.gz", hash = "sha256:2b45320af6dfaa1750f543d714b6d1c520a1688dec6fd24d339063ce0aaa9ac3"},
 ]
 pycodestyle = [
-    {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
-    {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
+    {file = "pycodestyle-2.10.0-py2.py3-none-any.whl", hash = "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610"},
+    {file = "pycodestyle-2.10.0.tar.gz", hash = "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053"},
 ]
 pyflakes = [
-    {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
-    {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
+    {file = "pyflakes-3.0.1-py2.py3-none-any.whl", hash = "sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf"},
+    {file = "pyflakes-3.0.1.tar.gz", hash = "sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd"},
 ]
 pygments = [
     {file = "Pygments-2.13.0-py3-none-any.whl", hash = "sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ numpy = "^1.23.5"
 pytest = "^7.1.1"
 ipdb = "^0.13.9"
 autopep8 = "^1.6.0"
-flake8 = "^4.0.1"
 pytest-cov = "^3.0.0"
 mock = "^4.0.3"
 
@@ -25,9 +24,20 @@ mock = "^4.0.3"
 mypy = "^0.991"
 types-requests = "^2.28.11.5"
 types-mock = "^4.0.15.2"
+flake8 = "^6.0.0"
+black = "^22.10.0"
 
 [tool.autopep8]
 max_line_length = 79
+
+[tool.black]
+line-length = 79
+
+[tool.flake8]
+max-line-length = 50
+extend-ignore = ["E203"]
+max-complexity = 2
+select = ["E9", "F63", "F7", "F82"]
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ numpy = "^1.23.5"
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.1"
 ipdb = "^0.13.9"
-autopep8 = "^1.6.0"
 pytest-cov = "^3.0.0"
 mock = "^4.0.3"
 
@@ -26,9 +25,6 @@ types-requests = "^2.28.11.5"
 types-mock = "^4.0.15.2"
 flake8 = "^6.0.0"
 black = "^22.10.0"
-
-[tool.autopep8]
-max_line_length = 79
 
 [tool.black]
 line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,12 +33,6 @@ max_line_length = 79
 [tool.black]
 line-length = 79
 
-[tool.flake8]
-max-line-length = 50
-extend-ignore = ["E203"]
-max-complexity = 2
-select = ["E9", "F63", "F7", "F82"]
-
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"

--- a/python_tsp/distances/great_circle_distance.py
+++ b/python_tsp/distances/great_circle_distance.py
@@ -46,12 +46,17 @@ def great_circle_distance_matrix(
 
     delta_sigma = np.arctan2(
         np.sqrt(
-            (np.cos(phi2) * np.sin(delta_lambda))**2 +
-            (np.cos(phi1) * np.sin(phi2) -
-             np.sin(phi1) * np.cos(phi2) * np.cos(delta_lambda))**2
+            (np.cos(phi2) * np.sin(delta_lambda)) ** 2
+            + (
+                np.cos(phi1) * np.sin(phi2)
+                - np.sin(phi1) * np.cos(phi2) * np.cos(delta_lambda)
+            )
+            ** 2
         ),
-        (np.sin(phi1) * np.sin(phi2) +
-         np.cos(phi1) * np.cos(phi2) * np.cos(delta_lambda))
+        (
+            np.sin(phi1) * np.sin(phi2)
+            + np.cos(phi1) * np.cos(phi2) * np.cos(delta_lambda)
+        ),
     )
 
     return EARTH_RADIUS_METERS * delta_sigma

--- a/python_tsp/distances/tsplib_distance.py
+++ b/python_tsp/distances/tsplib_distance.py
@@ -22,9 +22,9 @@ def tsplib_distance_matrix(tsplib_file: str) -> np.ndarray:
     """
 
     tsp_problem = tsplib95.load(tsplib_file)
-    distance_matrix_flattened = np.array([
-        tsp_problem.get_weight(*edge) for edge in tsp_problem.get_edges()
-    ])
+    distance_matrix_flattened = np.array(
+        [tsp_problem.get_weight(*edge) for edge in tsp_problem.get_edges()]
+    )
     distance_matrix = np.reshape(
         distance_matrix_flattened,
         (tsp_problem.dimension, tsp_problem.dimension),

--- a/python_tsp/heuristics/local_search.py
+++ b/python_tsp/heuristics/local_search.py
@@ -5,7 +5,8 @@ from typing import List, Optional, Tuple, TextIO
 import numpy as np
 
 from python_tsp.utils import (
-    compute_permutation_distance, setup_initial_solution
+    compute_permutation_distance,
+    setup_initial_solution,
 )
 from python_tsp.heuristics.perturbation_schemes import neighborhood_gen
 
@@ -79,9 +80,7 @@ def solve_tsp_local_search(
         improvement = False
         for n_index, xn in enumerate(neighborhood_gen[perturbation_scheme](x)):
             if default_timer() - tic > max_processing_time:
-                _print_message(
-                    TIME_LIMIT_MSG, verbose, log_file_handler
-                )
+                _print_message(TIME_LIMIT_MSG, verbose, log_file_handler)
                 stop_early = True
                 break
 

--- a/python_tsp/heuristics/perturbation_schemes.py
+++ b/python_tsp/heuristics/perturbation_schemes.py
@@ -117,7 +117,7 @@ def two_opt_gen(x: List[int]) -> Generator[List[int], List[int], None]:
         j_range = range(i + 1, n + 1)
         for j in sample(j_range, len(j_range)):
             xn = x.copy()
-            xn = xn[:i - 1] + list(reversed(xn[i - 1:j])) + xn[j:]
+            xn = xn[: i - 1] + list(reversed(xn[i - 1: j])) + xn[j:]
             yield xn
 
 

--- a/python_tsp/heuristics/simulated_annealing.py
+++ b/python_tsp/heuristics/simulated_annealing.py
@@ -6,7 +6,8 @@ import numpy as np
 
 from python_tsp.heuristics.perturbation_schemes import neighborhood_gen
 from python_tsp.utils import (
-    compute_permutation_distance, setup_initial_solution
+    compute_permutation_distance,
+    setup_initial_solution,
 )
 
 
@@ -22,7 +23,7 @@ def solve_tsp_simulated_annealing(
     alpha: float = 0.9,
     max_processing_time: Optional[float] = None,
     log_file: Optional[str] = None,
-    verbose: bool = False
+    verbose: bool = False,
 ) -> Tuple[List, float]:
     """Solve a TSP problem using a Simulated Annealing
     The approach used here is the one proposed in [1].
@@ -88,9 +89,7 @@ def solve_tsp_simulated_annealing(
         k_accepted = 0  # number of accepted perturbations
         for k in range(k_inner_max):
             if default_timer() - tic > max_processing_time:
-                _print_message(
-                    TIME_LIMIT_MSG, verbose, log_file_handler
-                )
+                _print_message(TIME_LIMIT_MSG, verbose, log_file_handler)
                 stop_early = True
                 break
 

--- a/tests/data.py
+++ b/tests/data.py
@@ -6,34 +6,40 @@ import numpy as np
 
 
 # Symmetric distance matrix
-distance_matrix1 = np.array([
-    [0, 2, 4, 6, 8],
-    [2, 0, 3, 5, 7],
-    [4, 6, 0, 4, 6],
-    [6, 5, 4, 0, 7],
-    [8, 5, 6, 7, 0],
-])
+distance_matrix1 = np.array(
+    [
+        [0, 2, 4, 6, 8],
+        [2, 0, 3, 5, 7],
+        [4, 6, 0, 4, 6],
+        [6, 5, 4, 0, 7],
+        [8, 5, 6, 7, 0],
+    ]
+)
 optimal_permutation1 = [0, 2, 3, 4, 1]
 optimal_distance1 = 22
 
 # Unsymmetric distance matrix
-distance_matrix2 = np.array([
-    [0, 2, 4, 6, 8],
-    [3, 0, 3, 5, 7],
-    [4, 7, 0, 4, 6],
-    [5, 5, 3, 0, 7],
-    [6, 3, 4, 5, 0],
-])
+distance_matrix2 = np.array(
+    [
+        [0, 2, 4, 6, 8],
+        [3, 0, 3, 5, 7],
+        [4, 7, 0, 4, 6],
+        [5, 5, 3, 0, 7],
+        [6, 3, 4, 5, 0],
+    ]
+)
 optimal_permutation2 = [0, 1, 2, 4, 3]
 optimal_distance2 = 21
 
 # Open problem (the returning cost is 0)
-distance_matrix3 = np.array([
-    [0, 2, 4, 6, 8],
-    [0, 0, 3, 5, 7],
-    [0, 6, 0, 4, 6],
-    [0, 5, 4, 0, 7],
-    [0, 5, 6, 7, 0],
-])
+distance_matrix3 = np.array(
+    [
+        [0, 2, 4, 6, 8],
+        [0, 0, 3, 5, 7],
+        [0, 6, 0, 4, 6],
+        [0, 5, 4, 0, 7],
+        [0, 5, 6, 7, 0],
+    ]
+)
 optimal_permutation3 = [0, 1, 2, 3, 4]
 optimal_distance3 = 16

--- a/tests/distances/test_data_processing.py
+++ b/tests/distances/test_data_processing.py
@@ -7,9 +7,7 @@ def test_1d_array_becomes_2d():
     source = np.array([1, -1])
     destination = np.array([5, -5])
 
-    sources_out, destinations_out = process_input(
-        source, destination
-    )
+    sources_out, destinations_out = process_input(source, destination)
 
     assert sources_out.shape == (1, 2)
     assert destinations_out.shape == (1, 2)

--- a/tests/distances/test_euclidean_distance.py
+++ b/tests/distances/test_euclidean_distance.py
@@ -25,7 +25,7 @@ def test_distance_is_euclidean():
 
     distance_matrix = euclidean_distance_matrix(source, destination)
 
-    assert distance_matrix[0] == 5.
+    assert distance_matrix[0] == 5.0
 
 
 def test_all_elements_are_non_negative(sources, destinations):

--- a/tests/distances/test_great_circle_distance.py
+++ b/tests/distances/test_great_circle_distance.py
@@ -43,8 +43,7 @@ def test_matrix_has_proper_shape(sources, destinations):
 
 
 def test_distance_works_with_1d_arrays(sources, destinations):
-    """The code is vectorized for 2d arrays, but should work for 1d as well
-    """
+    """The code is vectorized for 2d arrays, but should work for 1d as well"""
     source = sources[0]
     destination = destinations[0]
 

--- a/tests/exact/test_brute_force.py
+++ b/tests/exact/test_brute_force.py
@@ -2,9 +2,15 @@ import pytest
 
 from python_tsp.exact import solve_tsp_brute_force
 from tests.data import (
-    distance_matrix1, distance_matrix2, distance_matrix3,
-    optimal_permutation1, optimal_permutation2, optimal_permutation3,
-    optimal_distance1, optimal_distance2, optimal_distance3
+    distance_matrix1,
+    distance_matrix2,
+    distance_matrix3,
+    optimal_permutation1,
+    optimal_permutation2,
+    optimal_permutation3,
+    optimal_distance1,
+    optimal_distance2,
+    optimal_distance3,
 )
 
 
@@ -27,7 +33,7 @@ def test_solution_has_all_nodes(distance_matrix):
         (distance_matrix1, optimal_permutation1, optimal_distance1),
         (distance_matrix2, optimal_permutation2, optimal_distance2),
         (distance_matrix3, optimal_permutation3, optimal_distance3),
-    ]
+    ],
 )
 def test_solution_is_optimal(
     distance_matrix, expected_permutation, expected_distance

--- a/tests/exact/test_dynamic_programming.py
+++ b/tests/exact/test_dynamic_programming.py
@@ -2,9 +2,15 @@ import pytest
 
 from python_tsp.exact import solve_tsp_dynamic_programming
 from tests.data import (
-    distance_matrix1, distance_matrix2, distance_matrix3,
-    optimal_permutation1, optimal_permutation2, optimal_permutation3,
-    optimal_distance1, optimal_distance2, optimal_distance3
+    distance_matrix1,
+    distance_matrix2,
+    distance_matrix3,
+    optimal_permutation1,
+    optimal_permutation2,
+    optimal_permutation3,
+    optimal_distance1,
+    optimal_distance2,
+    optimal_distance3,
 )
 
 
@@ -27,7 +33,7 @@ def test_solution_has_all_nodes(distance_matrix):
         (distance_matrix1, optimal_permutation1, optimal_distance1),
         (distance_matrix2, optimal_permutation2, optimal_distance2),
         (distance_matrix3, optimal_permutation3, optimal_distance3),
-    ]
+    ],
 )
 def test_solution_is_optimal(
     distance_matrix, expected_permutation, expected_distance

--- a/tests/heuristics/test_local_search.py
+++ b/tests/heuristics/test_local_search.py
@@ -8,9 +8,15 @@ from python_tsp.heuristics import local_search
 from python_tsp.heuristics.perturbation_schemes import neighborhood_gen
 from python_tsp.utils import compute_permutation_distance
 from tests.data import (
-    distance_matrix1, distance_matrix2, distance_matrix3,
-    optimal_permutation1, optimal_permutation2, optimal_permutation3,
-    optimal_distance1, optimal_distance2, optimal_distance3
+    distance_matrix1,
+    distance_matrix2,
+    distance_matrix3,
+    optimal_permutation1,
+    optimal_permutation2,
+    optimal_permutation3,
+    optimal_distance1,
+    optimal_distance2,
+    optimal_distance3,
 )
 
 
@@ -19,8 +25,7 @@ PERTURBATION_SCHEMES = neighborhood_gen.keys()
 
 @pytest.mark.parametrize("scheme", PERTURBATION_SCHEMES)
 @pytest.mark.parametrize(
-    "distance_matrix",
-    [distance_matrix1, distance_matrix2, distance_matrix3]
+    "distance_matrix", [distance_matrix1, distance_matrix2, distance_matrix3]
 )
 def test_local_search_returns_better_neighbor(scheme, distance_matrix):
     """
@@ -44,7 +49,7 @@ def test_local_search_returns_better_neighbor(scheme, distance_matrix):
         (distance_matrix1, optimal_permutation1, optimal_distance1),
         (distance_matrix2, optimal_permutation2, optimal_distance2),
         (distance_matrix3, optimal_permutation3, optimal_distance3),
-    ]
+    ],
 )
 def test_local_search_returns_equal_optimal_solution(
     scheme, distance_matrix, optimal_permutation, optimal_distance
@@ -85,7 +90,7 @@ def test_local_search_with_time_constraints(scheme):
         distance_matrix,
         perturbation_scheme=scheme,
         max_processing_time=max_processing_time,
-        verbose=True
+        verbose=True,
     )
 
     assert local_search.TIME_LIMIT_MSG in captured_output.getvalue()
@@ -98,9 +103,7 @@ def test_log_file_is_created_if_required(tmp_path):
 
     log_file = tmp_path / "tmp_log_file.log"
 
-    local_search.solve_tsp_local_search(
-        distance_matrix1, log_file=log_file
-    )
+    local_search.solve_tsp_local_search(distance_matrix1, log_file=log_file)
 
     assert log_file.exists()
     assert "Current value" in log_file.read_text()

--- a/tests/heuristics/test_simulated_annealing.py
+++ b/tests/heuristics/test_simulated_annealing.py
@@ -7,7 +7,9 @@ import pytest
 from python_tsp.heuristics import simulated_annealing
 from python_tsp.heuristics.perturbation_schemes import neighborhood_gen
 from tests.data import (
-    distance_matrix1, distance_matrix2, distance_matrix3,
+    distance_matrix1,
+    distance_matrix2,
+    distance_matrix3,
 )
 
 
@@ -20,8 +22,7 @@ def permutation():
 
 
 @pytest.mark.parametrize(
-    "distance_matrix",
-    [distance_matrix1, distance_matrix2, distance_matrix3]
+    "distance_matrix", [distance_matrix1, distance_matrix2, distance_matrix3]
 )
 @pytest.mark.parametrize("scheme", PERTURBATION_SCHEMES)
 def test_simulated_annealing_solution_is_valid(
@@ -62,7 +63,7 @@ def test_simulated_annealing_with_time_constraints(permutation, scheme):
         distance_matrix,
         perturbation_scheme=scheme,
         max_processing_time=max_processing_time,
-        verbose=True
+        verbose=True,
     )
 
     assert simulated_annealing.TIME_LIMIT_MSG in captured_output.getvalue()

--- a/tests/utils/test_permutation_distance.py
+++ b/tests/utils/test_permutation_distance.py
@@ -2,17 +2,15 @@ import pytest
 
 from python_tsp.utils import compute_permutation_distance
 from tests.data import (
-    distance_matrix1, distance_matrix2, distance_matrix3,
+    distance_matrix1,
+    distance_matrix2,
+    distance_matrix3,
 )
 
 
 @pytest.mark.parametrize(
     "distance_matrix, expected_distance",
-    [
-        (distance_matrix1, 28),
-        (distance_matrix2, 26),
-        (distance_matrix3, 20)
-    ]
+    [(distance_matrix1, 28), (distance_matrix2, 26), (distance_matrix3, 20)],
 )
 def test_return_correct_permutation_distance(
     distance_matrix, expected_distance
@@ -29,11 +27,7 @@ def test_return_correct_permutation_distance(
 
 @pytest.mark.parametrize(
     "distance_matrix, expected_distance",
-    [
-        (distance_matrix1, 28),
-        (distance_matrix2, 26),
-        (distance_matrix3, 20)
-    ]
+    [(distance_matrix1, 28), (distance_matrix2, 26), (distance_matrix3, 20)],
 )
 def test_return_correct_permutation_distance_initial_node_not_zero(
     distance_matrix, expected_distance

--- a/tests/utils/test_setup_initial_solution.py
+++ b/tests/utils/test_setup_initial_solution.py
@@ -2,17 +2,15 @@ import pytest
 
 from python_tsp.utils import setup_initial_solution
 from tests.data import (
-    distance_matrix1, distance_matrix2, distance_matrix3,
+    distance_matrix1,
+    distance_matrix2,
+    distance_matrix3,
 )
 
 
 @pytest.mark.parametrize(
     "distance_matrix, expected_distance",
-    [
-        (distance_matrix1, 28),
-        (distance_matrix2, 26),
-        (distance_matrix3, 20)
-    ]
+    [(distance_matrix1, 28), (distance_matrix2, 26), (distance_matrix3, 20)],
 )
 def test_setup_return_same_setup(distance_matrix, expected_distance):
     """
@@ -28,8 +26,7 @@ def test_setup_return_same_setup(distance_matrix, expected_distance):
 
 
 @pytest.mark.parametrize(
-    "distance_matrix",
-    [distance_matrix1, distance_matrix2, distance_matrix3]
+    "distance_matrix", [distance_matrix1, distance_matrix2, distance_matrix3]
 )
 def test_setup_return_random_valid_solution(distance_matrix):
     """


### PR DESCRIPTION
The `autopep8` formatting is not really being helpful; a lot of large lines are begin skipped, and its overall "aggressive" formatting is not that good with comparison with the more opinionated `black`.

Thus, we replaced `autopep8` with `black` here. 