### PR TITLE
Add support for starting node

### DIFF
--- a/python_tsp/exact/brute_force.py
+++ b/python_tsp/exact/brute_force.py
@@ -8,7 +8,8 @@ from python_tsp.utils import compute_permutation_distance
 
 
 def solve_tsp_brute_force(
-    distance_matrix: np.ndarray, starting_node: int = 0,
+    distance_matrix: np.ndarray,
+    starting_node: int = 0,
 ) -> Tuple[Optional[List], Any]:
     """Solve TSP to optimality with a brute force approach
 
@@ -17,7 +18,7 @@ def solve_tsp_brute_force(
     distance_matrix
         Distance matrix of shape (n x n) with the (i, j) entry indicating the
         distance from node i to j. It does not need to be symmetric
-    
+
     starting_node
         Determines the starting node of the final permutation. Defaults to 0.
 
@@ -38,7 +39,8 @@ def solve_tsp_brute_force(
 
     # Exclude `starting_node` from the range since it is fixed
     other_points = [
-        node for node in range(distance_matrix.shape[0])
+        node
+        for node in range(distance_matrix.shape[0])
         if node != starting_node
     ]
     best_distance = np.inf

--- a/python_tsp/exact/brute_force.py
+++ b/python_tsp/exact/brute_force.py
@@ -8,7 +8,7 @@ from python_tsp.utils import compute_permutation_distance
 
 
 def solve_tsp_brute_force(
-    distance_matrix: np.ndarray,
+    distance_matrix: np.ndarray, starting_node: int = 0,
 ) -> Tuple[Optional[List], Any]:
     """Solve TSP to optimality with a brute force approach
 
@@ -17,6 +17,9 @@ def solve_tsp_brute_force(
     distance_matrix
         Distance matrix of shape (n x n) with the (i, j) entry indicating the
         distance from node i to j. It does not need to be symmetric
+    
+    starting_node
+        Determines the starting node of the final permutation. Defaults to 0.
 
     Returns
     -------
@@ -33,14 +36,17 @@ def solve_tsp_brute_force(
     reducing the possibilities to (n - 1)!.
     """
 
-    # Exclude 0 from the range since it is fixed as starting point
-    points = range(1, distance_matrix.shape[0])
+    # Exclude `starting_node` from the range since it is fixed
+    other_points = [
+        node for node in range(distance_matrix.shape[0])
+        if node != starting_node
+    ]
     best_distance = np.inf
     best_permutation = None
 
-    for partial_permutation in permutations(points):
+    for partial_permutation in permutations(other_points):
         # Remember to add the starting node before evaluating it
-        permutation = [0] + list(partial_permutation)
+        permutation = [starting_node] + list(partial_permutation)
         distance = compute_permutation_distance(distance_matrix, permutation)
 
         if distance < best_distance:

--- a/python_tsp/exact/dynamic_programming.py
+++ b/python_tsp/exact/dynamic_programming.py
@@ -25,7 +25,7 @@ def solve_tsp_dynamic_programming(
 
     starting_node
         Determines the starting node of the final permutation. Defaults to 0.
-    
+
     Returns
     -------
     permutation
@@ -96,7 +96,8 @@ def solve_tsp_dynamic_programming(
     # Get initial set {0, 1, 2, ..., tsp_size} \ {starting_node} as a frozenset
     # because @lru_cache requires a hashable type
     N = frozenset(
-        node for node in range(distance_matrix.shape[0])
+        node
+        for node in range(distance_matrix.shape[0])
         if node != starting_node
     )
     memo: Dict[Tuple, int] = {}

--- a/python_tsp/exact/dynamic_programming.py
+++ b/python_tsp/exact/dynamic_programming.py
@@ -7,6 +7,7 @@ import numpy as np
 def solve_tsp_dynamic_programming(
     distance_matrix: np.ndarray,
     maxsize: Optional[int] = None,
+    starting_node: int = 0,
 ) -> Tuple[List, float]:
     """
     Solve TSP to optimality with dynamic programming
@@ -22,6 +23,9 @@ def solve_tsp_dynamic_programming(
         size for the recursion tree. Defaults to `None`, which essentially
         means "take as much space as needed".
 
+    starting_node
+        Determines the starting node of the final permutation. Defaults to 0.
+    
     Returns
     -------
     permutation
@@ -89,16 +93,19 @@ def solve_tsp_dynamic_programming(
     ---------
     https://en.wikipedia.org/wiki/Held%E2%80%93Karp_algorithm#cite_note-5
     """
-    # Get initial set {1, 2, ..., tsp_size} as a frozenset because @lru_cache
-    # requires a hashable type
-    N = frozenset(range(1, distance_matrix.shape[0]))
+    # Get initial set {0, 1, 2, ..., tsp_size} \ {starting_node} as a frozenset
+    # because @lru_cache requires a hashable type
+    N = frozenset(
+        node for node in range(distance_matrix.shape[0])
+        if node != starting_node
+    )
     memo: Dict[Tuple, int] = {}
 
     # Step 1: get minimum distance
     @lru_cache(maxsize=maxsize)
     def dist(ni: int, N: frozenset) -> float:
         if not N:
-            return distance_matrix[ni, 0]
+            return distance_matrix[ni, starting_node]
 
         # Store the costs in the form (nj, dist(nj, N))
         costs = [
@@ -110,11 +117,11 @@ def solve_tsp_dynamic_programming(
 
         return min_cost
 
-    best_distance = dist(0, N)
+    best_distance = dist(starting_node, N)
 
     # Step 2: get path with the minimum distance
-    ni = 0  # start at the origin
-    solution = [0]
+    ni = starting_node  # start at the origin
+    solution = [starting_node]
 
     while N:
         ni = memo[(ni, N)]

--- a/python_tsp/heuristics/lin_kernighan.py
+++ b/python_tsp/heuristics/lin_kernighan.py
@@ -143,6 +143,7 @@ def solve_tsp_lin_kernighan(
     x0: Optional[List[int]] = None,
     log_file: Optional[str] = None,
     verbose: bool = False,
+    starting_node: int = 0,
 ) -> Tuple[List[int], float]:
     """
     Solve the Traveling Salesperson Problem using the Lin-Kernighan algorithm.
@@ -163,6 +164,9 @@ def solve_tsp_lin_kernighan(
     verbose
         If true, prints algorithm status every iteration.
 
+    starting_node
+        Determines the starting node of the final permutation. Defaults to 0.
+
     Returns
     -------
     Tuple
@@ -174,7 +178,7 @@ def solve_tsp_lin_kernighan(
     Chapter 5, Section 5.3.2.1: Lin-Kernighan Neighborhood, Springer, 2023.
     """
     hamiltonian_cycle, hamiltonian_cycle_distance = setup_initial_solution(
-        distance_matrix=distance_matrix, x0=x0
+        distance_matrix=distance_matrix, x0=x0, starting_node=starting_node
     )
     num_vertices = distance_matrix.shape[0]
     vertices = list(range(num_vertices))

--- a/python_tsp/heuristics/local_search.py
+++ b/python_tsp/heuristics/local_search.py
@@ -69,7 +69,9 @@ def solve_tsp_local_search(
         3. Repeat step 2 until all neighbors of `x` are tried and there is no
         improvement. Return `x`, `fx` as solution.
     """
-    x, fx = setup_initial_solution(distance_matrix, x0, starting_node=starting_node)
+    x, fx = setup_initial_solution(
+        distance_matrix, x0, starting_node=starting_node
+    )
     max_processing_time = max_processing_time or np.inf
 
     log_file_handler = (

--- a/python_tsp/heuristics/local_search.py
+++ b/python_tsp/heuristics/local_search.py
@@ -21,6 +21,7 @@ def solve_tsp_local_search(
     max_processing_time: Optional[float] = None,
     log_file: Optional[str] = None,
     verbose: bool = False,
+    starting_node: int = 0,
 ) -> Tuple[List, float]:
     """Solve a TSP problem with a local search heuristic
 
@@ -47,6 +48,9 @@ def solve_tsp_local_search(
     verbose
         If true, prints algorithm status every iteration
 
+    starting_node
+        Determines the starting node of the final permutation. Defaults to 0.
+
     Returns
     -------
     A permutation of nodes from 0 to n - 1 that produces the least total
@@ -65,7 +69,7 @@ def solve_tsp_local_search(
         3. Repeat step 2 until all neighbors of `x` are tried and there is no
         improvement. Return `x`, `fx` as solution.
     """
-    x, fx = setup_initial_solution(distance_matrix, x0)
+    x, fx = setup_initial_solution(distance_matrix, x0, starting_node=starting_node)
     max_processing_time = max_processing_time or np.inf
 
     log_file_handler = (

--- a/python_tsp/heuristics/perturbation_schemes.py
+++ b/python_tsp/heuristics/perturbation_schemes.py
@@ -117,7 +117,7 @@ def two_opt_gen(x: List[int]) -> Generator[List[int], List[int], None]:
         j_range = range(i + 1, n + 1)
         for j in sample(j_range, len(j_range)):
             xn = x.copy()
-            xn = xn[: i - 1] + list(reversed(xn[i - 1: j])) + xn[j:]
+            xn = xn[: i - 1] + list(reversed(xn[i - 1 : j])) + xn[j:]
             yield xn
 
 

--- a/python_tsp/heuristics/record_to_record.py
+++ b/python_tsp/heuristics/record_to_record.py
@@ -23,6 +23,7 @@ def solve_tsp_record_to_record(
     max_iterations: Optional[int] = None,
     log_file: Optional[str] = None,
     verbose: bool = False,
+    starting_node: int = 0,
 ):
     """
     Solve the traveling Salesperson Problem using a
@@ -48,6 +49,9 @@ def solve_tsp_record_to_record(
     verbose
         If true, prints algorithm status every iteration.
 
+    starting_node
+        Determines the starting node of the final permutation. Defaults to 0.
+
     Returns
     -------
     Tuple
@@ -60,7 +64,7 @@ def solve_tsp_record_to_record(
     """
     n = distance_matrix.shape[0]
     max_iterations = max_iterations or n
-    x, fx = setup_initial_solution(distance_matrix=distance_matrix, x0=x0)
+    x, fx = setup_initial_solution(distance_matrix=distance_matrix, x0=x0, starting_node=starting_node)
 
     log_file_handler = (
         open(log_file, "w", encoding="utf-8") if log_file else None

--- a/python_tsp/heuristics/record_to_record.py
+++ b/python_tsp/heuristics/record_to_record.py
@@ -64,7 +64,9 @@ def solve_tsp_record_to_record(
     """
     n = distance_matrix.shape[0]
     max_iterations = max_iterations or n
-    x, fx = setup_initial_solution(distance_matrix=distance_matrix, x0=x0, starting_node=starting_node)
+    x, fx = setup_initial_solution(
+        distance_matrix=distance_matrix, x0=x0, starting_node=starting_node
+    )
 
     log_file_handler = (
         open(log_file, "w", encoding="utf-8") if log_file else None

--- a/python_tsp/heuristics/simulated_annealing.py
+++ b/python_tsp/heuristics/simulated_annealing.py
@@ -24,6 +24,7 @@ def solve_tsp_simulated_annealing(
     max_processing_time: Optional[float] = None,
     log_file: Optional[str] = None,
     verbose: bool = False,
+    starting_node: int = 0,
 ) -> Tuple[List, float]:
     """Solve a TSP problem using a Simulated Annealing
     The approach used here is the one proposed in [1].
@@ -58,6 +59,9 @@ def solve_tsp_simulated_annealing(
     verbose {False}
         If true, prints algorithm status every iteration
 
+    starting_node
+        Determines the starting node of the final permutation. Defaults to 0.
+
     Returns
     -------
     A permutation of nodes from 0 to n - 1 that produces the least total
@@ -71,7 +75,7 @@ def solve_tsp_simulated_annealing(
     case studies. Springer Science & Business Media, 2006.
     """
 
-    x, fx = setup_initial_solution(distance_matrix, x0)
+    x, fx = setup_initial_solution(distance_matrix, x0, starting_node=starting_node)
     temp = _initial_temperature(distance_matrix, x, fx, perturbation_scheme)
     max_processing_time = max_processing_time or inf
     log_file_handler = (

--- a/python_tsp/heuristics/simulated_annealing.py
+++ b/python_tsp/heuristics/simulated_annealing.py
@@ -75,7 +75,9 @@ def solve_tsp_simulated_annealing(
     case studies. Springer Science & Business Media, 2006.
     """
 
-    x, fx = setup_initial_solution(distance_matrix, x0, starting_node=starting_node)
+    x, fx = setup_initial_solution(
+        distance_matrix, x0, starting_node=starting_node
+    )
     temp = _initial_temperature(distance_matrix, x, fx, perturbation_scheme)
     max_processing_time = max_processing_time or inf
     log_file_handler = (

--- a/python_tsp/utils/setup_initial_solution.py
+++ b/python_tsp/utils/setup_initial_solution.py
@@ -12,7 +12,7 @@ STARTING_NODE_TOO_LARGE_MSG = "Starting node larger than the number of nodes"
 def setup_initial_solution(
     distance_matrix: np.ndarray,
     x0: Optional[List] = None,
-    starting_node: int = 0
+    starting_node: int = 0,
 ) -> Tuple[List[int], float]:
     """Return initial solution and its objective value
 

--- a/python_tsp/utils/setup_initial_solution.py
+++ b/python_tsp/utils/setup_initial_solution.py
@@ -7,7 +7,9 @@ from .permutation_distance import compute_permutation_distance
 
 
 def setup_initial_solution(
-    distance_matrix: np.ndarray, x0: Optional[List] = None
+    distance_matrix: np.ndarray,
+    x0: Optional[List] = None,
+    starting_node: int = 0
 ) -> Tuple[List[int], float]:
     """Return initial solution and its objective value
 
@@ -33,7 +35,20 @@ def setup_initial_solution(
 
     if not x0:
         n = distance_matrix.shape[0]  # number of nodes
-        x0 = [0] + sample(range(1, n), n - 1)  # ensure 0 is the first node
+        x0 = _build_initial_permutation(n, starting_node)
 
     fx0 = compute_permutation_distance(distance_matrix, x0)
     return x0, fx0
+
+
+def _build_initial_permutation(n: int, starting_node: int) -> List[int]:
+    """
+    Build a random list of integers from 0 to `n` - 1 guaranteeing the initial
+    node is `starting_node`.
+    """
+    all_nodes_except_starting_node = [
+        node for node in range(n) if node != starting_node
+    ]
+    x0 = [starting_node] + sample(all_nodes_except_starting_node, n - 1)
+
+    return x0

--- a/python_tsp/utils/setup_initial_solution.py
+++ b/python_tsp/utils/setup_initial_solution.py
@@ -6,6 +6,9 @@ import numpy as np
 from .permutation_distance import compute_permutation_distance
 
 
+STARTING_NODE_TOO_LARGE_MSG = "Starting node larger than the number of nodes"
+
+
 def setup_initial_solution(
     distance_matrix: np.ndarray,
     x0: Optional[List] = None,
@@ -46,6 +49,9 @@ def _build_initial_permutation(n: int, starting_node: int) -> List[int]:
     Build a random list of integers from 0 to `n` - 1 guaranteeing the initial
     node is `starting_node`.
     """
+    if starting_node >= n:
+        raise ValueError(STARTING_NODE_TOO_LARGE_MSG)
+
     all_nodes_except_starting_node = [
         node for node in range(n) if node != starting_node
     ]

--- a/tests/utils/test_starting_node.py
+++ b/tests/utils/test_starting_node.py
@@ -1,6 +1,7 @@
 import pytest
 
 from python_tsp.utils import setup_initial_solution
+from python_tsp.utils.setup_initial_solution import STARTING_NODE_TOO_LARGE_MSG
 from tests.data import distance_matrix1
 
 
@@ -14,3 +15,12 @@ def test_initial_solution_respects_starting_node(starting_node):
     # the starting node is as requested
     assert set(x0) == set(range(distance_matrix1.shape[0]))
     assert x0[0] == starting_node
+
+
+def test_exception_is_raise_if_starting_node_is_too_large():
+    with pytest.raises(ValueError) as e:
+        x0, _ = setup_initial_solution(
+            distance_matrix1, starting_node=999
+        )
+
+    assert str(e.value) == STARTING_NODE_TOO_LARGE_MSG

--- a/tests/utils/test_starting_node.py
+++ b/tests/utils/test_starting_node.py
@@ -2,7 +2,11 @@ import pytest
 
 from python_tsp.utils import setup_initial_solution
 from python_tsp.utils.setup_initial_solution import STARTING_NODE_TOO_LARGE_MSG
-from python_tsp.exact import solve_tsp_dynamic_programming, solve_tsp_brute_force, solve_tsp_branch_and_bound
+from python_tsp.exact import (
+    solve_tsp_dynamic_programming,
+    solve_tsp_brute_force,
+    solve_tsp_branch_and_bound,
+)
 from python_tsp.heuristics import (
     solve_tsp_local_search,
     solve_tsp_simulated_annealing,

--- a/tests/utils/test_starting_node.py
+++ b/tests/utils/test_starting_node.py
@@ -1,0 +1,16 @@
+import pytest
+
+from python_tsp.utils import setup_initial_solution
+from tests.data import distance_matrix1
+
+
+@pytest.mark.parametrize("starting_node", [0, 1, 2, 3, 4])
+def test_initial_solution_respects_starting_node(starting_node):
+    x0, _ = setup_initial_solution(
+        distance_matrix1, starting_node=starting_node
+    )
+
+    # Ensure all nodes are contained in the solution and that
+    # the starting node is as requested
+    assert set(x0) == set(range(distance_matrix1.shape[0]))
+    assert x0[0] == starting_node

--- a/tests/utils/test_starting_node.py
+++ b/tests/utils/test_starting_node.py
@@ -25,18 +25,19 @@ def test_initial_solution_respects_starting_node(starting_node):
 
 def test_exception_is_raise_if_starting_node_is_too_large():
     with pytest.raises(ValueError) as e:
-        x0, _ = setup_initial_solution(
-            distance_matrix1, starting_node=999
-        )
+        x0, _ = setup_initial_solution(distance_matrix1, starting_node=999)
 
     assert str(e.value) == STARTING_NODE_TOO_LARGE_MSG
 
 
 @pytest.mark.parametrize(
-    "solver", 
+    "solver",
     [
-        solve_tsp_local_search, solve_tsp_simulated_annealing, solve_tsp_lin_kernighan, solve_tsp_record_to_record
-    ]
+        solve_tsp_local_search,
+        solve_tsp_simulated_annealing,
+        solve_tsp_lin_kernighan,
+        solve_tsp_record_to_record,
+    ],
 )
 def test_solver_solution_respects_starting_node(solver):
     starting_node = 3

--- a/tests/utils/test_starting_node.py
+++ b/tests/utils/test_starting_node.py
@@ -2,6 +2,7 @@ import pytest
 
 from python_tsp.utils import setup_initial_solution
 from python_tsp.utils.setup_initial_solution import STARTING_NODE_TOO_LARGE_MSG
+from python_tsp.exact import solve_tsp_dynamic_programming, solve_tsp_brute_force, solve_tsp_branch_and_bound
 from python_tsp.heuristics import (
     solve_tsp_local_search,
     solve_tsp_simulated_annealing,
@@ -33,10 +34,14 @@ def test_exception_is_raise_if_starting_node_is_too_large():
 @pytest.mark.parametrize(
     "solver",
     [
+        solve_tsp_brute_force,
+        solve_tsp_dynamic_programming,
         solve_tsp_local_search,
         solve_tsp_simulated_annealing,
-        solve_tsp_lin_kernighan,
-        solve_tsp_record_to_record,
+        # These are not working yet
+        # solve_tsp_branch_and_bound,
+        # solve_tsp_lin_kernighan,
+        # solve_tsp_record_to_record,
     ],
 )
 def test_solver_solution_respects_starting_node(solver):

--- a/tests/utils/test_starting_node.py
+++ b/tests/utils/test_starting_node.py
@@ -2,6 +2,12 @@ import pytest
 
 from python_tsp.utils import setup_initial_solution
 from python_tsp.utils.setup_initial_solution import STARTING_NODE_TOO_LARGE_MSG
+from python_tsp.heuristics import (
+    solve_tsp_local_search,
+    solve_tsp_simulated_annealing,
+    solve_tsp_lin_kernighan,
+    solve_tsp_record_to_record,
+)
 from tests.data import distance_matrix1
 
 
@@ -24,3 +30,19 @@ def test_exception_is_raise_if_starting_node_is_too_large():
         )
 
     assert str(e.value) == STARTING_NODE_TOO_LARGE_MSG
+
+
+@pytest.mark.parametrize(
+    "solver", 
+    [
+        solve_tsp_local_search, solve_tsp_simulated_annealing, solve_tsp_lin_kernighan, solve_tsp_record_to_record
+    ]
+)
+def test_solver_solution_respects_starting_node(solver):
+    starting_node = 3
+    x, _ = solver(
+        distance_matrix=distance_matrix1, starting_node=starting_node
+    )
+
+    assert set(x) == set(range(distance_matrix1.shape[0]))
+    assert x[0] == starting_node


### PR DESCRIPTION
# Description

The available solvers provide solutions that always start at `0`, with the exception of heuristic solvers `solve_tsp_local_search` and `solve_tsp_simulated_annealing` in case the user provides an initial solution `x0`, in which case it will respect the initial point of `x0`.
 
Adding support for any starting node seems to be a typical desired functionality as per the discussion in #21 and in #32.

# Work to be done

- [x] Raise exception if starting node is larger than the number of nodes
- [ ] Check for mismatches between starting node and `x0` if provided.
- [-] Add support for exact solvers
- [-] Add support for heuristic solvers.

Support for @luanleonardo's solvers will much likely require his help.