### PR TITLE
Adding discrete seeds to TSP solvers

### DIFF
--- a/python_tsp/heuristics/perturbation_schemes.py
+++ b/python_tsp/heuristics/perturbation_schemes.py
@@ -12,64 +12,69 @@ References
     339-355.
 .. [2] 2-opt: https://en.wikipedia.org/wiki/2-opt
 """
-from random import sample
+from random import Random
 from typing import Callable, Dict, Generator, List
 
+initial_random_generator = Random()
 
-def ps1_gen(x: List[int]) -> Generator[List[int], List[int], None]:
+def ps1_gen(x: List[int], rng: Random = None) -> Generator[List[int], List[int], None]:
     """PS1 perturbation scheme: Swap two adjacent terms [1]
     This scheme has at most n - 1 swaps.
     """
+    rng = rng or initial_random_generator
 
     n = len(x)
     i_range = range(1, n - 1)
-    for i in sample(i_range, len(i_range)):
+    for i in rng.sample(i_range, len(i_range)):
         xn = x.copy()
         xn[i], xn[i + 1] = xn[i + 1], xn[i]
         yield xn
 
 
-def ps2_gen(x: List[int]) -> Generator[List[int], List[int], None]:
+def ps2_gen(x: List[int], rng: Random = None) -> Generator[List[int], List[int], None]:
     """PS2 perturbation scheme: Swap any two elements [1]
     This scheme has n * (n - 1) / 2 swaps.
     """
+    rng = rng or initial_random_generator
 
     n = len(x)
     i_range = range(1, n - 1)
-    for i in sample(i_range, len(i_range)):
+    for i in rng.sample(i_range, len(i_range)):
         j_range = range(i + 1, n)
-        for j in sample(j_range, len(j_range)):
+        for j in rng.sample(j_range, len(j_range)):
             xn = x.copy()
             xn[i], xn[j] = xn[j], xn[i]
             yield xn
 
 
-def ps3_gen(x: List[int]) -> Generator[List[int], List[int], None]:
+def ps3_gen(x: List[int], rng: Random = None) -> Generator[List[int], List[int], None]:
     """PS3 perturbation scheme: A single term is moved [1]
     This scheme has n * (n - 1) swaps.
     """
+    rng = rng or initial_random_generator
 
     n = len(x)
     i_range = range(1, n)
-    for i in sample(i_range, len(i_range)):
+    for i in rng.sample(i_range, len(i_range)):
         j_range = [j for j in range(1, n) if j != i]
-        for j in sample(j_range, len(j_range)):
+        for j in rng.sample(j_range, len(j_range)):
             xn = x.copy()
             node = xn.pop(i)
             xn.insert(j, node)
             yield xn
 
 
-def ps4_gen(x: List[int]) -> Generator[List[int], List[int], None]:
+def ps4_gen(x: List[int], rng: Random = None) -> Generator[List[int], List[int], None]:
     """PS4 perturbation scheme: A subsequence is moved [1]"""
+    rng = rng or initial_random_generator
 
     n = len(x)
     i_range = range(1, n)
-    for i in sample(i_range, len(i_range)):
+    for i in rng.sample(i_range, len(i_range)):
         j_range = range(i + 1, n + 1)
-        for j in sample(j_range, len(j_range)):
+        for j in rng.sample(j_range, len(j_range)):
             k_range = [k for k in range(1, n + 1) if k not in range(i, j + 1)]
-            for k in sample(k_range, len(k_range)):
+            for k in rng.sample(k_range, len(k_range)):
                 xn = x.copy()
                 if k < i:
                     xn = xn[:k] + xn[i:j] + xn[k:i] + xn[j:]
@@ -78,29 +83,31 @@ def ps4_gen(x: List[int]) -> Generator[List[int], List[int], None]:
                 yield xn
 
 
-def ps5_gen(x: List[int]) -> Generator[List[int], List[int], None]:
+def ps5_gen(x: List[int], rng: Random = None) -> Generator[List[int], List[int], None]:
     """PS5 perturbation scheme: A subsequence is reversed [1]"""
+    rng = rng or initial_random_generator
 
     n = len(x)
     i_range = range(1, n)
-    for i in sample(i_range, len(i_range)):
+    for i in rng.sample(i_range, len(i_range)):
         j_range = range(i + 2, n + 1)
-        for j in sample(j_range, len(j_range)):
+        for j in rng.sample(j_range, len(j_range)):
             xn = x.copy()
             xn = xn[:i] + list(reversed(xn[i:j])) + xn[j:]
             yield xn
 
 
-def ps6_gen(x: List[int]) -> Generator[List[int], List[int], None]:
+def ps6_gen(x: List[int], rng: Random = None) -> Generator[List[int], List[int], None]:
     """PS6 perturbation scheme: A subsequence is reversed and moved [1]"""
+    rng = rng or initial_random_generator
 
     n = len(x)
     i_range = range(1, n)
-    for i in sample(i_range, len(i_range)):
+    for i in rng.sample(i_range, len(i_range)):
         j_range = range(i + 1, n + 1)
-        for j in sample(j_range, len(j_range)):
+        for j in rng.sample(j_range, len(j_range)):
             k_range = [k for k in range(1, n + 1) if k not in range(i, j + 1)]
-            for k in sample(k_range, len(k_range)):
+            for k in rng.sample(k_range, len(k_range)):
                 xn = x.copy()
                 if k < i:
                     xn = xn[:k] + list(reversed(xn[i:j])) + xn[k:i] + xn[j:]
@@ -109,13 +116,15 @@ def ps6_gen(x: List[int]) -> Generator[List[int], List[int], None]:
                 yield xn
 
 
-def two_opt_gen(x: List[int]) -> Generator[List[int], List[int], None]:
+def two_opt_gen(x: List[int], rng: Random = None) -> Generator[List[int], List[int], None]:
     """2-opt perturbation scheme [2]"""
+    rng = rng or initial_random_generator
+    
     n = len(x)
     i_range = range(2, n)
-    for i in sample(i_range, len(i_range)):
+    for i in rng.sample(i_range, len(i_range)):
         j_range = range(i + 1, n + 1)
-        for j in sample(j_range, len(j_range)):
+        for j in rng.sample(j_range, len(j_range)):
             xn = x.copy()
             xn = xn[: i - 1] + list(reversed(xn[i - 1 : j])) + xn[j:]
             yield xn
@@ -123,7 +132,7 @@ def two_opt_gen(x: List[int]) -> Generator[List[int], List[int], None]:
 
 # Mapping with all possible neighborhood generators in this module
 neighborhood_gen: Dict[
-    str, Callable[[List[int]], Generator[List[int], List[int], None]]
+    str, Callable[[List[int], Random], Generator[List[int], List[int], None]]
 ] = {
     "ps1": ps1_gen,
     "ps2": ps2_gen,

--- a/python_tsp/heuristics/simulated_annealing.py
+++ b/python_tsp/heuristics/simulated_annealing.py
@@ -106,7 +106,7 @@ def solve_tsp_simulated_annealing(
             xn = _perturbation(x, perturbation_scheme, rng=rng)
             fn = compute_permutation_distance(distance_matrix, xn)
 
-            if _acceptance_rule(fx, fn, temp):
+            if _acceptance_rule(fx, fn, temp, rng=rng):
                 x, fx = xn, fn
                 k_accepted += 1
                 k_noimprovements = 0
@@ -192,8 +192,9 @@ def _perturbation(x: List[int], perturbation_scheme: str, rng:  Optional[Random]
 
 def _acceptance_rule(fx: float, fn: float, temp: float, rng: Optional[Random]) -> bool:
     """Metropolis acceptance rule"""
+    rand = rng.random() if rng else np.random.rand()
 
     dfx = fn - fx
     return (dfx < 0) or (
-        (dfx > 0) and (rng.random() <= np.exp(-(fn - fx) / temp))
+        (dfx > 0) and (rand <= np.exp(-(fn - fx) / temp))
     )

--- a/python_tsp/heuristics/simulated_annealing.py
+++ b/python_tsp/heuristics/simulated_annealing.py
@@ -1,5 +1,6 @@
 from math import inf
 from timeit import default_timer
+from random import Random
 from typing import List, Optional, Tuple, TextIO
 
 import numpy as np
@@ -12,6 +13,7 @@ from python_tsp.utils import (
 
 
 TIME_LIMIT_MSG = "WARNING: Stopping early due to time constraints"
+ITERATION_LIMIT_MSG = "WARNING: Stopping early due to iteration limit"
 MAX_NON_IMPROVEMENTS = 3
 MAX_INNER_ITERATIONS_MULTIPLIER = 10
 
@@ -22,6 +24,8 @@ def solve_tsp_simulated_annealing(
     perturbation_scheme: str = "two_opt",
     alpha: float = 0.9,
     max_processing_time: Optional[float] = None,
+    max_iterations: Optional[int] = None,
+    rng: Optional[Random] = None,
     log_file: Optional[str] = None,
     verbose: bool = False,
 ) -> Tuple[List, float]:
@@ -72,7 +76,7 @@ def solve_tsp_simulated_annealing(
     """
 
     x, fx = setup_initial_solution(distance_matrix, x0)
-    temp = _initial_temperature(distance_matrix, x, fx, perturbation_scheme)
+    temp = _initial_temperature(distance_matrix, x, fx, perturbation_scheme, rng=rng)
     max_processing_time = max_processing_time or inf
     log_file_handler = (
         open(log_file, "w", encoding="utf-8") if log_file else None
@@ -85,15 +89,21 @@ def solve_tsp_simulated_annealing(
 
     tic = default_timer()
     stop_early = False
+    i = 0
     while (k_noimprovements < MAX_NON_IMPROVEMENTS) and (not stop_early):
         k_accepted = 0  # number of accepted perturbations
         for k in range(k_inner_max):
+            i += 1
             if default_timer() - tic > max_processing_time:
                 _print_message(TIME_LIMIT_MSG, verbose, log_file_handler)
                 stop_early = True
                 break
+            if max_iterations and i > max_iterations:
+                _print_message(ITERATION_LIMIT_MSG, verbose, log_file_handler)
+                stop_early = True
+                break
 
-            xn = _perturbation(x, perturbation_scheme)
+            xn = _perturbation(x, perturbation_scheme, rng=rng)
             fn = compute_permutation_distance(distance_matrix, xn)
 
             if _acceptance_rule(fx, fn, temp):
@@ -136,6 +146,7 @@ def _initial_temperature(
     x: List[int],
     fx: float,
     perturbation_scheme: str,
+    rng: Optional[Random],
 ) -> float:
     """Compute initial temperature
     Instead of relying on problem-dependent parameters, this function estimates
@@ -159,7 +170,7 @@ def _initial_temperature(
     # Step 1
     dfx_list = []
     for _ in range(100):
-        xn = _perturbation(x, perturbation_scheme)
+        xn = _perturbation(x, perturbation_scheme, rng=rng)
         fn = compute_permutation_distance(distance_matrix, xn)
         dfx_list.append(fn - fx)
 
@@ -170,19 +181,19 @@ def _initial_temperature(
     return -dfx_mean / np.log(tau0)
 
 
-def _perturbation(x: List[int], perturbation_scheme: str):
+def _perturbation(x: List[int], perturbation_scheme: str, rng:  Optional[Random]):
     """Generate a random neighbor of a current solution ``x``
     In this case, we can use the generators created in the `local_search`
     module, and pick the first solution. Since the neighborhood is randomized,
     it is the same as creating a random perturbation.
     """
-    return next(neighborhood_gen[perturbation_scheme](x))
+    return next(neighborhood_gen[perturbation_scheme](x, rng=rng))
 
 
-def _acceptance_rule(fx: float, fn: float, temp: float) -> bool:
+def _acceptance_rule(fx: float, fn: float, temp: float, rng: Optional[Random]) -> bool:
     """Metropolis acceptance rule"""
 
     dfx = fn - fx
     return (dfx < 0) or (
-        (dfx > 0) and (np.random.rand() <= np.exp(-(fn - fx) / temp))
+        (dfx > 0) and (rng.random() <= np.exp(-(fn - fx) / temp))
     )


### PR DESCRIPTION
I have made it so that the local_search and simulated annealing will take in a python `random.Random` pre seeded RNG which can create the needed numbers for making perturbations or for other use cases in each solver.